### PR TITLE
travis-miniconda installer fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ virtualenv:
 env:
   matrix:
     # let's start simple:
-    - PYTHON_VERSION="2.7" LATEST="true"
+    - PYTHON_VERSION="2.7" LATEST="true" "DEAP_VERSION=1.0.1"
     - PYTHON_VERSION="3.4" LATEST="true" "DEAP_VERSION=1.0.1"
-    - PYTHON_VERSION="3.5" LATEST="true"
+    - PYTHON_VERSION="3.5" LATEST="true" "DEAP_VERSION=1.0.1"
     #- PYTHON_VERSION="3.4" COVERAGE="true" LATEST="true"
 install: source ./ci/.travis_install.sh
 script: bash ./ci/.travis_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   matrix:
     # let's start simple:
     #- PYTHON_VERSION="2.7" LATEST="true"
-    - PYTHON_VERSION="3.4" LATEST="true" "DEAP_VERSION=1.0.2"
+    - PYTHON_VERSION="3.4" LATEST="true" "DEAP_VERSION=1.0.1"
     #- PYTHON_VERSION="3.5" LATEST="true"
     #- PYTHON_VERSION="3.4" COVERAGE="true" LATEST="true"
 install: source ./ci/.travis_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   matrix:
     # let's start simple:
     #- PYTHON_VERSION="2.7" LATEST="true"
-    - PYTHON_VERSION="3.4" LATEST="true"
+    - PYTHON_VERSION="3.4" LATEST="true" "DEAP_VERSION=1.0.2"
     #- PYTHON_VERSION="3.5" LATEST="true"
     #- PYTHON_VERSION="3.4" COVERAGE="true" LATEST="true"
 install: source ./ci/.travis_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ virtualenv:
 env:
   matrix:
     # let's start simple:
-    #- PYTHON_VERSION="2.7" LATEST="true"
+    - PYTHON_VERSION="2.7" LATEST="true"
     - PYTHON_VERSION="3.4" LATEST="true" "DEAP_VERSION=1.0.1"
-    #- PYTHON_VERSION="3.5" LATEST="true"
+    - PYTHON_VERSION="3.5" LATEST="true"
     #- PYTHON_VERSION="3.4" COVERAGE="true" LATEST="true"
 install: source ./ci/.travis_install.sh
 script: bash ./ci/.travis_test.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/rhiever/tpot.svg?branch=master)](https://travis-ci.org/rhiever/tpot)
+
 # Tree-based Pipeline Optimization Tool (TPOT)
 
 Consider TPOT your **Data Science Assistant**. TPOT is a Python tool that automatically creates and optimizes Machine Learning pipelines using genetic programming.

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -41,9 +41,9 @@ else
 	      pandas=$PANDAS_VERSION \
         cython
 fi
-pip install deap==$DEAP_VERSION
 
 source activate testenv
+pip install deap==$DEAP_VERSION
 
 if [[ "$COVERAGE" == "true" ]]; then
     pip install coverage coveralls

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -39,9 +39,9 @@ else
         numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
         scikit-learn=$SKLEARN_VERSION \
 	      pandas=$PANDAS_VERSION \
-		    deap=$DEAP_VERSION \
         cython
 fi
+pip install deap==$DEAP_VERSION
 
 source activate testenv
 

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -23,7 +23,7 @@ deactivate
 
 # Use the miniconda installer for faster download / install of conda
 # itself
-wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
+wget http://repo.continuum.io/miniconda/Miniconda-3.9.1-Linux-x86_64.sh \
     -O miniconda.sh
 chmod +x miniconda.sh && ./miniconda.sh -b
 export PATH=/home/travis/miniconda/bin:$PATH
@@ -38,8 +38,8 @@ else
     conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
         numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
         scikit-learn=$SKLEARN_VERSION \
-	    pandas=$PANDAS_VERSION \
-		deap=$DEAP_VERSION \
+	      pandas=$PANDAS_VERSION \
+		    deap=$DEAP_VERSION \
         cython
 fi
 

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -33,7 +33,7 @@ conda update --yes conda
 # provided versions
 if [[ "$LATEST" == "true" ]]; then
     conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
-        numpy scipy scikit-learn cython pandas deap
+        numpy scipy scikit-learn cython pandas
 else
     conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
         numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \


### PR DESCRIPTION
Okay, let me fix the travis-ci from pullrequest #15 
From now on, it will be a bit easier to debug it before it's merged since we will be able to see the travis reports. 

- this also adds the tracking of the "build" status to the Readme file that you were asking about

I really don't understand this bug regarding the miniconda installation.
In the previous version, I selected the "latest" Miniconda Linux built from http://repo.continuum.io/miniconda/ (`Miniconda-latest-Linux-x86_64.sh`), which apparently doesn't work for some reason. However, selecting, e.g., `Miniconda-3.9.1-Linux-x86_64.sh` does work.
Anyway, let's see
