### PR TITLE
Replace scikit GB with XGB in docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -26,14 +26,14 @@ pages:
   - examples/IRIS_Example.md
   - examples/Titanic_Kaggle_Example.md
   - examples/Custom_Scoring_Functions.md
-- Reference: 
+- Reference:
   - Index: ref_index.md
   - TPOT Object: reference/TPOT.md
   - Pipeline Operators:
     - Models:
       - DecisionTreeClassifier: reference/pipeline_operators/models/classifiers/tree/DecisionTreeClassifier.md
       - RandomForestClassifier: reference/pipeline_operators/models/classifiers/ensemble/RandomForestClassifier.md
-      - GradientBoostingClassifier: reference/pipeline_operators/models/classifiers/ensemble/GradientBoostingClassifier.md
+      - XGBClassifier: reference/pipeline_operators/models/classifiers/ensemble/XGBClassifier.md
       - SVC: reference/pipeline_operators/models/classifiers/svm/SVC.md
       - kNeighborsClassifier: reference/pipeline_operators/models/classifiers/nearest_neighbors/kNeighborsClassifier.md
       - LogisticRegression: reference/pipeline_operators/models/classifiers/linear_model/LogisticRegression.md
@@ -41,7 +41,7 @@ pages:
       - StandardScaler: reference/pipeline_operators/preprocessing/scaling/StandardScaler.md
       - RobustScaler: reference/pipeline_operators/preprocessing/scaling/RobustScaler.md
       - PolynomialFeatures: reference/pipeline_operators/preprocessing/PolynomialFeatures.md
-    - Feature Selection: 
+    - Feature Selection:
       - VarianceThreshold: reference/pipeline_operators/feature_selection/VarianceThreshold.md
       - SelectKBest: reference/pipeline_operators/feature_selection/SelectKBest.md
       - SelectPercentile: reference/pipeline_operators/feature_selection/SelectPercentile.md

--- a/docs/sources/ref_index.md
+++ b/docs/sources/ref_index.md
@@ -9,7 +9,7 @@
 ## Models
 * [pipeline_operators.models.tree.DecisionTreeClassifier](reference/pipeline_operators/models/classifiers/tree/DecisionTreeClassifier.md)
 * [pipeline_operators.models.ensemble.RandomForestClassifier](reference/pipeline_operators/models/classifiers/ensemble/RandomForestClassifier.md)
-* [pipeline_operators.models.ensemble.GradientBoostingClassifier](reference/pipeline_operators/models/classifiers/ensemble/GradientBoostingClassifier)
+* [pipeline_operators.models.ensemble.XGBClassifier](reference/pipeline_operators/models/classifiers/ensemble/XGBClassifier)
 * [pipeline_operators.models.svm.SVC](reference/pipeline_operators/models/classifiers/svm/SVC.md)
 * [pipeline_operators.models.nearest_neighbors.kNeighborsClassifier](reference/pipeline_operators/models/classifiers/nearest_neighbors/kNeighborsClassifier.md)
 * [pipeline_operators.models.linear_model.LogisticRegression](reference/pipeline_operators/models/classifiers/linear_model/LogisticRegression.md)
@@ -28,5 +28,3 @@
 
 ## Decomposition
 *  [pipeline_operators.decomposition.RandomizedPCA](reference/pipeline_operators/decomposition/RandomizedPCA.md)
-
-

--- a/docs/sources/reference/pipeline_operators/models/classifiers/ensemble/XGBClassifier.md
+++ b/docs/sources/reference/pipeline_operators/models/classifiers/ensemble/XGBClassifier.md
@@ -1,16 +1,16 @@
-# Gradient Boosting Classifier
-* * * 
+# XGBoost Classifier
+* * *
 
-Fits a Gradient Boosting classifier.
+Fits the dmlc eXtreme gradient boosting classifier.
 
 ## Dependencies
-    sklearn.ensemble.GradientBoostingClassifier
+    xgboost.XGBClassifier
 
 
 Parameters
 ----------
     input_df: pandas.DataFrame {n_samples, n_features+['class', 'group', 'guess']}
-        Input DataFrame for fitting the gradient boosting classifier
+        Input DataFrame for fitting the XGBoost classifier
     learning_rate: float
         Shrinks the contribution of each tree by learning_rate
     n_estimators: int
@@ -32,7 +32,7 @@ Example Exported Code
 import numpy as np
 import pandas as pd
 from sklearn.cross_validation import StratifiedShuffleSplit
-from sklearn.ensemble import GradientBoostingClassifier
+from xgboost import XGBClassifier
 
 # NOTE: Make sure that the class is labeled 'class' in the data file
 tpot_data = pd.read_csv('PATH/TO/DATA/FILE', sep='COLUMN_SEPARATOR')
@@ -41,9 +41,9 @@ training_indices, testing_indices = next(iter(StratifiedShuffleSplit(tpot_data['
 result1 = tpot_data.copy()
 
 # Perform classification with a gradient boosting classifier
-gbc1 = GradientBoostingClassifier(learning_rate=0.0001, n_estimators=1, max_depth=None)
-gbc1.fit(result1.loc[training_indices].drop('class', axis=1).values, result1.loc[training_indices, 'class'].values)
+xgbc1 = XGBClassifier(learning_rate=0.0001, n_estimators=1, max_depth=None)
+xgbc1.fit(result1.loc[training_indices].drop('class', axis=1).values, result1.loc[training_indices, 'class'].values)
 
-result1['gbc1-classification'] = gbc1.predict(result1.drop('class', axis=1).values)
+result1['xgbc1-classification'] = xgbc1.predict(result1.drop('class', axis=1).values)
 
 ```

--- a/tpot/tpot.py
+++ b/tpot/tpot.py
@@ -541,7 +541,7 @@ training_indices, testing_indices = next(iter(StratifiedShuffleSplit(tpot_data['
         Parameters
         ----------
         input_df: pandas.DataFrame {n_samples, n_features+['class', 'group', 'guess']}
-            Input DataFrame for fitting the gradient boosting classifier
+            Input DataFrame for fitting the XGBoost classifier
         learning_rate: float
             Shrinks the contribution of each tree by learning_rate
         n_estimators: int


### PR DESCRIPTION
## What does this PR do?
Replaces the scikit GB classifier with the XGB classifier in the docs.


## Where should the reviewer start?
mkdocs.yml, ref_index.md, and XGBClassifier.md. Also made a minor change in tpot.py.


## How should this PR be tested?
Don't think so.


## Any background context you want to provide?
This fixes what was discussed in the previous XGBoost PR. #83 


## What are the relevant issues?

#83 

## Screenshots (if appropriate)



## Questions:

- Do the docs need to be updated?
They are being updated in this PR.
- Does this PR add new (Python) dependencies?
No
