### PR TITLE
First [uber hacky] attempt to address tpot issue #95: parallelizing t…

### DIFF
--- a/tpot/paralleltoolbox.py
+++ b/tpot/paralleltoolbox.py
@@ -1,0 +1,12 @@
+from deap import base
+
+class ParallelToolbox(base.Toolbox):
+    """Runs the TPOT genetic algorithm over multiple cores."""
+
+    def __getstate__(self):
+        self_dict = self.__dict__.copy()
+        del self_dict['map']
+        return self_dict
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)


### PR DESCRIPTION
This is a first attempt to parallelize the GA pipeline in tpot. Since tpot uses DEAP under the hood for the parallel algorithm, the parallelization strategy involves [overriding its `map` implementation](http://deap.readthedocs.org/en/master/tutorials/basic/part4.html).

The DEAP documentation specifies two methods for parallelization: SCOOP and Python's built-in `multiprocessing` library. The former is not feasible, given the entire package has to be run through it. The latter is possible, but there is a serialization error by which DEAP attempts to pickle the `Toolbox` object and, therefore, the encapsulated `Pool` object ([this error](
http://stackoverflow.com/questions/25382455/python-notimplementederror-pool-objects-cannot-be-passed-between-processes)).

The workaround implemented in this PR is to extend the DEAP ToolBox to include required `__getstate__` and `__setstate__` methods that eliminate the `Pool` object just prior to serialization.

## Where should the reviewer start?

The parallelization appears to work (see screenshot), but it's unclear if a whole separate subclass is required. `joblib` would be preferable here, but there doesn't seem to be a way to decouple the partial it generates from its dispatcher and hand that over to DEAP.

## How should this PR be tested?

Performance testing, primarily. From the more knowledgeable committers, a deeper dive into whether or not subclassing is really the answer here.

## Any background context you want to provide?

Mostly provided above. **This is not ready for inclusion**; several other important points remain, mainly a command-line parameter to control for parallelization. I just wanted to get the review process rolling.

## What are the relevant issues?

#95 

## Screenshots (if appropriate)

<img width="408" alt="screen shot 2016-03-01 at 4 27 39 pm" src="https://cloud.githubusercontent.com/assets/135417/13442744/b79d54f0-dfcb-11e5-9526-c3e24c62d838.png">

## Questions:

- Do the docs need to be updated?
Yes, we'll need to add a command-line parameter to control parallelization.

- Does this PR add new (Python) dependencies?
No, just a new module.