### PR TITLE
Removed incorrect exception raise in import code generation function

### DIFF
--- a/tpot/export_utils.py
+++ b/tpot/export_utils.py
@@ -161,7 +161,7 @@ def generate_import_code(pipeline_list):
             operator_import = import_relations[op]
             merge_imports(pipeline_imports, operator_import)
         except KeyError:
-            raise RuntimeError('{} operator in pipeline not detailed in export utils'.format(op))
+            pass # Operator does not require imports
 
     # Build import string
     for key in pipeline_imports.keys():


### PR DESCRIPTION
## What does this PR do?

Removes the `RuntimeError` exception that is raised when no import statements are defined for a pipeline operator

## Where should the reviewer start?

Line 164 in `tpot/export_utils.py`

## How should this PR be tested?

Currently the master branch will throw an exception if an exported pipeline uses any operators that don't require any imports (like `_combine_dfs()`). That behavior can be seen in the existing codebase, and can be tested in the teaearlgraycold/eu_imports_ref codebase to see that it does not persist.

## Questions:

- Do the docs need to be updated?

No

- Does this PR add new (Python) dependencies?

No

---

Instead of removing the exception I could alternatively require people to enter blank dicts for operators that do not require import statements, but that seems less preferable.