### PR TITLE
Hide UserWarning events about tolerance when using the FastICA operator

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -517,7 +517,6 @@ def test_fast_ica_2():
 
     assert in_rows == out_rows
 
-
 def test_feat_agg():
     """Assert that the TPOT FeatureAgglomeration preprocessor outputs the input dataframe
     when the number of training features is 0"""

--- a/tpot/export_utils.py
+++ b/tpot/export_utils.py
@@ -600,7 +600,8 @@ else:
 
         elif operator_name == '_fast_ica':
             n_components = int(operator[3])
-            tol = float(operator[4])
+            tol = max(float(operator[4]), 0.0001) # Ensure tol is not too small
+
             if n_components < 1:
                 n_components = 1
             n_components = 'min({}, len(training_features.columns.values))'.format(n_components)

--- a/tpot/tpot.py
+++ b/tpot/tpot.py
@@ -1168,6 +1168,9 @@ class TPOT(object):
         else:
             n_components = min(n_components, len(training_features.columns.values))
 
+        # Ensure that tol does not get to be too small
+        tol = max(tol, 0.0001)
+
         ica = FastICA(n_components=n_components, tol=tol, random_state=42)
         ica.fit(training_features.values.astype(np.float64))
         transformed_features = ica.transform(input_df.drop(self.non_feature_columns, axis=1).values.astype(np.float64))

--- a/tpot/tpot.py
+++ b/tpot/tpot.py
@@ -1172,9 +1172,14 @@ class TPOT(object):
         tol = max(tol, 0.0001)
 
         ica = FastICA(n_components=n_components, tol=tol, random_state=42)
-        ica.fit(training_features.values.astype(np.float64))
-        transformed_features = ica.transform(input_df.drop(self.non_feature_columns, axis=1).values.astype(np.float64))
 
+        # Ignore convergence warnings during GP
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=UserWarning)
+
+            ica.fit(training_features.values.astype(np.float64))
+
+        transformed_features = ica.transform(input_df.drop(self.non_feature_columns, axis=1).values.astype(np.float64))
         modified_df = pd.DataFrame(data=transformed_features)
 
         for non_feature_column in self.non_feature_columns:


### PR DESCRIPTION
## What does this PR do?

Attempts to prevent convergence warnings during calls to _fast_ica.

Also outright hides the warnings if they do occur.

## Where should the reviewer start?

Most changes should be in the _fast_ica method of the TPOT class

## How should this PR be tested?

It wouldn't really be reasonable to write a test for this issue, but running a couple of datasets through TPOT a few times should show that `UserWarning` events no longer are displayed in stdout.

## What are the relevant issues?

#148 

## Questions:

- Do the docs need to be updated?

No 

- Does this PR add new (Python) dependencies?

No