### PR TITLE
Threshhold n_components in _fast_ica to duplicate the logic of the sklearn

### DIFF
--- a/tpot/tpot.py
+++ b/tpot/tpot.py
@@ -1356,7 +1356,14 @@ class TPOT(object):
         if n_components < 1:
             n_components = 1
         else:
-            n_components = min(n_components, len(training_features.columns.values))
+            n_components = len(training_features.columns.values)
+
+            # Temporarily copied logic from sklearn's FastICA code to prevent
+            # erronious debugging print statment from occuring
+            n, p = training_features.shape
+
+            if (n_components > min(n, p)):
+                    n_components = min(n, p)
 
         # Ensure that tol does not get to be too small
         tol = max(tol, 0.0001)


### PR DESCRIPTION
## What does this PR do?

Prevents the FastICA Sklearn operator from reaching an erroneous print statement by thresh-holding the n_components value.

## Where should the reviewer start?

The _fast_ica method in TPOT

## How should this PR be tested?

@rhiever, I don't believe you ever said what dataset was causing the warnings you were seeing. I haven't been able to recreate the warning personally, but if you were to run this branch on that dataset you should be able to confirm that the warning is no longer and issue.

## What are the relevant issues?

#153 