### PR TITLE
Replace calls to random with np.random

### DIFF
--- a/tpot/tpot.py
+++ b/tpot/tpot.py
@@ -1671,7 +1671,7 @@ class TPOT(object):
             Returns the individual with one of the mutations applied to it
 
         """
-        roll = random.random()
+        roll = np.random.random()
         if roll <= 0.333333:
             return gp.mutUniform(individual, expr=self._toolbox.expr_mut, pset=self._pset)
         elif roll <= 0.666666:


### PR DESCRIPTION
## What does this PR do?

Replaces the one call to random.random() in tpot.py with np.random.random().

Because deap still uses std. lib's random, I've left the code for seeding random for now.

## How should this PR be tested?

By comparing the behavior of `_random_mutation_operator()` across Python 2.7 and 3.X 

## What are the relevant issues?

#159

