### PR TITLE
Remove n_components argument from some operators (Fixes #163)

### DIFF
--- a/docs/sources/documentation/pipeline_operators/decomposition/FastICA.md
+++ b/docs/sources/documentation/pipeline_operators/decomposition/FastICA.md
@@ -11,8 +11,6 @@ Parameters
 ----------
     input_df: pandas.DataFrame {n_samples, n_features+['class', 'group', 'guess']}
         Input DataFrame to scale
-    n_components: int
-            The number of components to keep
     tol: float
         Tolerance on update at each iteration.
 
@@ -42,7 +40,7 @@ training_features = {INPUT_DF}.loc[training_indices].drop('class', axis=1)
 
 if len(training_features.columns.values) > 0:
     # FastICA must be fit on only the training data
-    ica = FastICA(n_components=2, tol=0.1, random_state=42)
+    ica = FastICA(tol=0.1, random_state=42)
     ica.fit(training_features.values.astype(np.float64))
     transformed_features = ica.transform(tpot_data.drop('class', axis=1).values.astype(np.float64))
     result1 = pd.DataFrame(data=transformed_features)

--- a/docs/sources/documentation/pipeline_operators/decomposition/RandomizedPCA.md
+++ b/docs/sources/documentation/pipeline_operators/decomposition/RandomizedPCA.md
@@ -11,8 +11,6 @@ Parameters
 ----------
     input_df: pandas.DataFrame {n_samples, n_features+['class', 'group', 'guess']}
         Input DataFrame to scale
-    n_components: int
-        The number of components to keep
     iterated_power: int
         Number of iterations for the power method. [1, 10]
 
@@ -42,7 +40,7 @@ training_features = tpot_data.loc[training_indices].drop('class', axis=1)
 
 if len(training_features.columns.values) > 0:
     # RandomizedPCA must be fit on only the training data
-    pca = RandomizedPCA(n_components=1, iterated_power=10)
+    pca = RandomizedPCA(iterated_power=10)
     pca.fit(training_features.values.astype(np.float64))
     transformed_features = pca.transform(tpot_data.drop('class', axis=1).values.astype(np.float64))
 

--- a/docs/sources/documentation/pipeline_operators/kernel_approximation/RBFSampler.md
+++ b/docs/sources/documentation/pipeline_operators/kernel_approximation/RBFSampler.md
@@ -13,8 +13,6 @@ Parameters
         Input DataFrame to scale
     gamma:
       Parameter of RBF kernel: exp(-gamma * x^2)
-    n_components: int
-        The number of components to keep
 
 Returns
 -------
@@ -44,7 +42,7 @@ training_features = result1.loc[training_indices].drop('class', axis=1)
 
 if len(training_features.columns.values) > 0:
     # RBF must be fit on only the training data
-    rbf = RBFSampler(n_components=min(59, len(training_features.columns.values)), gamma=0.001)
+    rbf = RBFSampler(gamma=0.001)
     rbf.fit(training_features.values.astype(np.float64))
     transformed_features = rbf.transform(result1.drop('class', axis=1).values.astype(np.float64))
     result1 = pd.DataFrame(data=transformed_features)

--- a/tests.py
+++ b/tests.py
@@ -465,7 +465,7 @@ def test_rbf():
     training features is 0"""
     tpot_obj = TPOT()
 
-    assert np.array_equal(tpot_obj._rbf(training_testing_data.ix[:,-3:], 0.1, 3),
+    assert np.array_equal(tpot_obj._rbf(training_testing_data.ix[:,-3:], 0.1),
                           training_testing_data.ix[:,-3:])
 
 def test_rbf_2():
@@ -477,7 +477,7 @@ def test_rbf_2():
     tpot_obj = TPOT()
 
     input_df = training_testing_data
-    output_df = tpot_obj._rbf(input_df, 0.1, 3)
+    output_df = tpot_obj._rbf(input_df, 0.1)
 
     assert type(input_df) == type(output_df)
 
@@ -491,7 +491,7 @@ def test_fast_ica():
     when the number of training features is 0"""
     tpot_obj = TPOT()
 
-    assert np.array_equal(tpot_obj._fast_ica(training_testing_data.ix[:,-3:], 1, 1.0),
+    assert np.array_equal(tpot_obj._fast_ica(training_testing_data.ix[:,-3:], 1.0),
                           training_testing_data.ix[:,-3:])
 
 def test_fast_ica_2():
@@ -503,7 +503,7 @@ def test_fast_ica_2():
     tpot_obj = TPOT()
 
     input_df = training_testing_data
-    output_df = tpot_obj._fast_ica(input_df, 1, 1.0)
+    output_df = tpot_obj._fast_ica(input_df, 1.0)
 
     assert type(input_df) == type(output_df)
 
@@ -580,7 +580,7 @@ def test_pca():
     """Ensure that the TPOT PCA outputs the input dataframe when no. of training features is 0"""
     tpot_obj = TPOT()
 
-    assert np.array_equal(tpot_obj._pca(training_testing_data.ix[:,-3:], 1, 1),training_testing_data.ix[:,-3:])
+    assert np.array_equal(tpot_obj._pca(training_testing_data.ix[:,-3:], 1),training_testing_data.ix[:,-3:])
 
 def test_zero_count():
     """Ensure that the TPOT _zero_count preprocessor outputs the input dataframe when no. of training features is 0"""

--- a/tpot/export_utils.py
+++ b/tpot/export_utils.py
@@ -667,11 +667,7 @@ else:
 '''.format(INPUT_DF=operator[2], OUTPUT_DF=result_name)
 
         elif operator_name == '_pca':
-            n_components = int(operator[3])
-            iterated_power = int(operator[4])
-            if n_components < 1:
-                n_components = 1
-            n_components = 'min({}, len(training_features.columns.values))'.format(n_components)
+            iterated_power = int(operator[3])
 
             if iterated_power < 1:
                 iterated_power = 1
@@ -684,18 +680,17 @@ training_features = {INPUT_DF}.loc[training_indices].drop('class', axis=1)
 
 if len(training_features.columns.values) > 0:
     # PCA must be fit on only the training data
-    pca = RandomizedPCA(n_components={N_COMPONENTS}, iterated_power={ITERATED_POWER})
+    pca = RandomizedPCA(iterated_power={ITERATED_POWER})
     pca.fit(training_features.values.astype(np.float64))
     transformed_features = pca.transform({INPUT_DF}.drop('class', axis=1).values.astype(np.float64))
     {OUTPUT_DF} = pd.DataFrame(data=transformed_features)
     {OUTPUT_DF}['class'] = {INPUT_DF}['class'].values
 else:
     {OUTPUT_DF} = {INPUT_DF}.copy()
-'''.format(INPUT_DF=operator[2], N_COMPONENTS=n_components, ITERATED_POWER=iterated_power, OUTPUT_DF=result_name)
+'''.format(INPUT_DF=operator[2], ITERATED_POWER=iterated_power, OUTPUT_DF=result_name)
 
         elif operator_name == '_rbf':
             gamma = float(operator[3])
-            n_components = int(operator[4])
             if n_components < 1:
                 n_components = 1
             n_components = 'min({}, len(training_features.columns.values))'.format(n_components)
@@ -706,18 +701,17 @@ training_features = {INPUT_DF}.loc[training_indices].drop('class', axis=1)
 
 if len(training_features.columns.values) > 0:
     # RBF must be fit on only the training data
-    rbf = RBFSampler(n_components={N_COMPONENTS}, gamma={GAMMA})
+    rbf = RBFSampler(gamma={GAMMA})
     rbf.fit(training_features.values.astype(np.float64))
     transformed_features = rbf.transform({INPUT_DF}.drop('class', axis=1).values.astype(np.float64))
     {OUTPUT_DF} = pd.DataFrame(data=transformed_features)
     {OUTPUT_DF}['class'] = {INPUT_DF}['class'].values
 else:
     {OUTPUT_DF} = {INPUT_DF}.copy()
-'''.format(INPUT_DF=operator[2], GAMMA=gamma, N_COMPONENTS=n_components, OUTPUT_DF=result_name)
+'''.format(INPUT_DF=operator[2], GAMMA=gamma, OUTPUT_DF=result_name)
 
         elif operator_name == '_fast_ica':
-            n_components = int(operator[3])
-            tol = max(float(operator[4]), 0.0001) # Ensure tol is not too small
+            tol = max(float(operator[3]), 0.0001) # Ensure tol is not too small
 
             if n_components < 1:
                 n_components = 1
@@ -729,14 +723,14 @@ training_features = {INPUT_DF}.loc[training_indices].drop('class', axis=1)
 
 if len(training_features.columns.values) > 0:
     # FastICA must be fit on only the training data
-    ica = FastICA(n_components={N_COMPONENTS}, tol={TOL}, random_state=42)
+    ica = FastICA(tol={TOL}, random_state=42)
     ica.fit(training_features.values.astype(np.float64))
     transformed_features = ica.transform({INPUT_DF}.drop('class', axis=1).values.astype(np.float64))
     {OUTPUT_DF} = pd.DataFrame(data=transformed_features)
     {OUTPUT_DF}['class'] = {INPUT_DF}['class'].values
 else:
     {OUTPUT_DF} = {INPUT_DF}.copy()
-'''.format(INPUT_DF=operator[2], N_COMPONENTS=n_components, TOL=tol, OUTPUT_DF=result_name)
+'''.format(INPUT_DF=operator[2], TOL=tol, OUTPUT_DF=result_name)
 
         elif operator_name == '_feat_agg':
             n_clusters = int(operator[3])


### PR DESCRIPTION
## What does this PR do?

Removes the n_components argument from _rbf, _pca, and _fast_ica

## How should this PR be tested?

With the integrated test suite

## What are the relevant issues?

#163 

