### PR TITLE
Remove params from class and tests

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -173,24 +173,6 @@ result2['dtc2-classification'] = dtc2.predict(result2.drop('class', axis=1).valu
     assert reference_code == exported_code
 
 
-def test_get_params():
-    """Ensure that get_params returns the exact dictionary of parameters used by TPOT"""
-    kwargs = {
-        'population_size': 500,
-        'generations': 1000,
-        'verbosity': 1
-    }
-
-    tpot_obj = TPOT(**kwargs)
-
-    # Get default parameters of TPOT and merge with our specified parameters
-    initializer = inspect.getargspec(TPOT.__init__)
-    default_kwargs = dict(zip(initializer.args[1:], initializer.defaults))
-    default_kwargs.update(kwargs)
-
-    assert tpot_obj.get_params() == default_kwargs
-
-
 def test_decision_tree():
     """Ensure that the TPOT decision tree method outputs the same as the sklearn decision tree"""
 

--- a/tpot/tpot.py
+++ b/tpot/tpot.py
@@ -104,10 +104,6 @@ class TPOT(object):
         None
 
         """
-        # Save params to be recalled later by get_params()
-        self.params = locals()  # Must be placed before any local variable definitions
-        self.params.pop('self')
-
         # Do not prompt the user to update during this session if they ever disabled the update check
         if disable_update_check:
             TPOT.update_checked = True
@@ -428,23 +424,6 @@ class TPOT(object):
         training_testing_data.rename(columns=new_col_names, inplace=True)
 
         return self._evaluate_individual(self._optimized_pipeline, training_testing_data)[1]
-
-    def get_params(self, deep=None):
-        """Get parameters for this estimator.
-
-        Parameters
-        ----------
-        deep: unused
-            Only implemented to maintain interface for sklearn
-
-        Returns
-        -------
-        params : mapping of string to any
-            Parameter names mapped to their values.
-
-        """
-
-        return self.params
 
     def export(self, output_file_name):
         """Exports the current optimized pipeline as Python code


### PR DESCRIPTION
## What does this PR do?

`params` attribute is defined, but never used. Removes `params` cruft from `TPOT` class, removes `get_params` from `TPOT`, and removes the tests. 

## Where should the reviewer start?

https://github.com/tonyfast/tpot/commit/d29c473e0037030f1f5628e2d231b742ad7be7d7

## How should this PR be tested?

All tests pass locally.

## Questions:

- Do the docs need to be updated? No
- Does this PR add new (Python) dependencies?  Yes

