### PR TITLE
Replace ARG0 with input_df in piplelines when serialized

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -76,10 +76,10 @@ def test_unroll_nested():
 
     tpot_obj = TPOT()
 
-    expected_list = [['result1', '_logistic_regression', 'ARG0', '1.0', '0', 'True']]
+    expected_list = [['result1', '_logistic_regression', 'input_df', '1.0', '0', 'True']]
 
     pipeline = creator.Individual.\
-        from_string('_logistic_regression(ARG0, 1.0, 0, True)', tpot_obj._pset)
+        from_string('_logistic_regression(input_df, 1.0, 0, True)', tpot_obj._pset)
 
     pipeline_list = unroll_nested_fuction_calls(pipeline)
 
@@ -103,8 +103,8 @@ tpot_data = pd.read_csv('PATH/TO/DATA/FILE', sep='COLUMN_SEPARATOR')
 training_indices, testing_indices = train_test_split(tpot_data.index, stratify = tpot_data['class'].values, train_size=0.75, test_size=0.25)
 """
 
-    pipeline = [['result1', '_variance_threshold', 'ARG0', '100.0'],
-                ['result2', '_pca', 'ARG0', '66', '34'],
+    pipeline = [['result1', '_variance_threshold', 'input_df', '100.0'],
+                ['result2', '_pca', 'input_df', '66', '34'],
                 ['result3', '_combine_dfs', 'result2', 'result1'],
                 ['result4', '_logistic_regression', 'result3', '0.12030075187969924', '0', 'True']]
 
@@ -129,8 +129,8 @@ tpot_data = pd.read_csv('PATH/TO/DATA/FILE', sep='COLUMN_SEPARATOR')
 training_indices, testing_indices = train_test_split(tpot_data.index, stratify = tpot_data['class'].values, train_size=0.75, test_size=0.25)
 """
 
-    pipeline = [['result1', '_fast_ica', 'ARG0', '5', '0.1'],
-                ['result2', '_pca', 'ARG0', '66', '34'],
+    pipeline = [['result1', '_fast_ica', 'input_df', '5', '0.1'],
+                ['result2', '_pca', 'input_df', '66', '34'],
                 ['result3', '_combine_dfs', 'result2', 'result1'],
                 ['result4', '_logistic_regression', 'result3', '0.12030075187969924', '0', 'True']]
 
@@ -165,7 +165,7 @@ result2 = result1.copy()
 result2['dtc2-classification'] = dtc2.predict(result2.drop('class', axis=1).values)
 """
 
-    pipeline = [['result1', '_select_kbest', 'ARG0', '26'],
+    pipeline = [['result1', '_select_kbest', 'input_df', '26'],
                 ['result2', '_decision_tree', 'result1', '0.1']]
 
     exported_code = replace_function_calls(pipeline)
@@ -326,7 +326,7 @@ def test_score_2():
 
     # Reify pipeline with known score
     tpot_obj._optimized_pipeline = creator.Individual.\
-        from_string('_logistic_regression(ARG0, 1.0, 0, True)', tpot_obj._pset)
+        from_string('_logistic_regression(input_df, 1.0, 0, True)', tpot_obj._pset)
 
     # Get score from TPOT
     score = tpot_obj.score(testing_features, testing_classes)
@@ -357,7 +357,7 @@ def test_predict_2():
     tpot_obj._training_classes = training_classes
     tpot_obj._training_features = training_features
     tpot_obj._optimized_pipeline = creator.Individual.\
-        from_string('_logistic_regression(ARG0, 1.0, 0, True)', tpot_obj._pset)
+        from_string('_logistic_regression(input_df, 1.0, 0, True)', tpot_obj._pset)
 
     result = tpot_obj.predict(testing_features)
 

--- a/tpot/export_utils.py
+++ b/tpot/export_utils.py
@@ -59,6 +59,10 @@ def unroll_nested_fuction_calls(exported_pipeline):
             break
         else:
             break
+
+    # Replace 'ARG0' with 'input_df'
+    pipeline_list = [[x if x != 'ARG0' else 'input_df' for x in pipeline_list[0]]]
+
     return pipeline_list
 
 
@@ -173,12 +177,12 @@ def replace_function_calls(pipeline_list):
         result_name = operator[0]
         operator_name = operator[1]
 
-        # Make copies of the data set for each reference to ARG0
-        if operator[2] == 'ARG0':
+        # Make copies of the data set for each reference to input_df
+        if operator[2] == 'input_df':
             operator[2] = 'result{}'.format(operator_num)
             operator_text += '\n{} = tpot_data.copy()\n'.format(operator[2])
 
-        if len(operator) > 3 and operator[3] == 'ARG0':
+        if len(operator) > 3 and operator[3] == 'input_df':
             operator[3] = 'result{}'.format(operator_num)
             operator_text += '\n{} = tpot_data.copy()\n'.format(operator[3])
 

--- a/tpot/export_utils.py
+++ b/tpot/export_utils.py
@@ -230,7 +230,7 @@ def replace_function_calls(pipeline_list):
                 dual = False
 
             operator_text += '\n# Perform classification with a logistic regression classifier'
-            operator_text += '\nlrc{OPERATOR_NUM} = LogisticRegression(C={C}, dual={DUAL}, penalty={PENALTY})\n'.format(OPERATOR_NUM=operator_num,
+            operator_text += '\nlrc{OPERATOR_NUM} = LogisticRegression(C={C}, dual={DUAL}, penalty="{PENALTY}")\n'.format(OPERATOR_NUM=operator_num,
                                                                                                                         C=C,
                                                                                                                         PENALTY=penalty_selection,
                                                                                                                         DUAL=dual)

--- a/tpot/tpot.py
+++ b/tpot/tpot.py
@@ -63,7 +63,6 @@ class Bool(object):
 
 
 class TPOT(object):
-
     """TPOT automatically creates and optimizes machine learning pipelines using genetic programming."""
 
     update_checked = False
@@ -138,6 +137,9 @@ class TPOT(object):
             np.random.seed(random_state)
 
         self._pset = gp.PrimitiveSetTyped('MAIN', [pd.DataFrame], pd.DataFrame)
+
+        # Rename pipeline input to "input_df"
+        self._pset.renameArguments(ARG0='input_df')
 
         # Machine learning model operators
         self._pset.addPrimitive(self._decision_tree, [pd.DataFrame, float], pd.DataFrame)


### PR DESCRIPTION
## What does this PR do?

Makes it so that when shown as a string pipelines show the input as "input_df" rather than "ARG0"

## Where should the reviewer start?

Running the tests, printing out a pipeline and checking that ARG0 is replaced with input_df

## How should this PR be tested?

The added logic should be covered by the tests