### PR TITLE
Bring XGBoost back as an optional dependency

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
 branch = True
 source = tpot
-include = */tpot/*
+include = tpot/*.py

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -46,8 +46,10 @@ source activate testenv
 
 if [[ "$LATEST" == "true" ]]; then
     pip install deap
+    pip install xgboost
 else
     pip install deap==$DEAP_VERSION
+    pip install xgboost==$XGBOOST_VERSION
 fi
 
 pip install update_checker
@@ -64,6 +66,7 @@ python -c "import scipy; print('scipy %s' % scipy.__version__)"
 python -c "import sklearn; print('sklearn %s' % sklearn.__version__)"
 python -c "import pandas; print('pandas %s' % pandas.__version__)"
 python -c "import deap; print('deap %s' % deap.__version__)"
+python -c "import xgboost; print('xgboost %s ' % xgboost.__version__)"
 python -c "import update_checker; print('update_checker %s' % update_checker.__version__)"
 python -c "import tqdm; print('tqdm %s' % tqdm.__version__)"
 python setup.py build_ext --inplace

--- a/ci/.travis_test.sh
+++ b/ci/.travis_test.sh
@@ -15,6 +15,7 @@ python -c "import scipy; print('scipy %s' % scipy.__version__)"
 python -c "import sklearn; print('sklearn %s' % sklearn.__version__)"
 python -c "import pandas; print('pandas %s' % pandas.__version__)"
 python -c "import deap; print('deap %s' % deap.__version__)"
+python -c "import xgboost; print('xgboost %s ' % xgboost.__version__)"
 python -c "import update_checker; print('update_checker %s ' % update_checker.__version__)"
 python -c "import tqdm; print('tqdm %s' % tqdm.__version__)"
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -30,6 +30,7 @@ pages:
     - Models:
       - DecisionTreeClassifier: documentation/pipeline_operators/models/classifiers/tree/DecisionTreeClassifier.md
       - RandomForestClassifier: documentation/pipeline_operators/models/classifiers/ensemble/RandomForestClassifier.md
+      - XGBClassifier: documentation/pipeline_operators/models/classifiers/ensemble/XGBClassifier.md
       - kNeighborsClassifier: documentation/pipeline_operators/models/classifiers/nearest_neighbors/kNeighborsClassifier.md
       - LogisticRegression: documentation/pipeline_operators/models/classifiers/linear_model/LogisticRegression.md
       - AdaBoost: documentation/pipeline_operators/models/classifiers/ensemble/AdaBoost.md

--- a/docs/sources/documentation/pipeline_operators/models/classifiers/ensemble/XGBClassifier.md
+++ b/docs/sources/documentation/pipeline_operators/models/classifiers/ensemble/XGBClassifier.md
@@ -17,8 +17,8 @@ Parameters
         Maximum number of features to use (proportion of total features)
     min_child_weight: int
         The minimum weighted fraction of the input samples required to be at a leaf node.
-    max_depth: int
-        Maximum depth of the individual estimators; the maximum depth limits the number of nodes in the tree
+    n_estimators: int
+        The number of estimators (boosting rounds) to perform
 
 Returns
 -------

--- a/docs/sources/documentation/pipeline_operators/models/classifiers/ensemble/XGBClassifier.md
+++ b/docs/sources/documentation/pipeline_operators/models/classifiers/ensemble/XGBClassifier.md
@@ -13,12 +13,12 @@ Parameters
         Input DataFrame for fitting the XGBoost classifier
     learning_rate: float
         Shrinks the contribution of each tree by learning_rate
-    max_depth: int
-        Maximum depth of the individual estimators; the maximum depth limits the number of nodes in the tree
     subsample: float
         Maximum number of features to use (proportion of total features)
-    min_child_weight: float
+    min_child_weight: int
         The minimum weighted fraction of the input samples required to be at a leaf node.
+    max_depth: int
+        Maximum depth of the individual estimators; the maximum depth limits the number of nodes in the tree
 
 Returns
 -------

--- a/docs/sources/documentation/pipeline_operators/models/classifiers/ensemble/XGBClassifier.md
+++ b/docs/sources/documentation/pipeline_operators/models/classifiers/ensemble/XGBClassifier.md
@@ -1,0 +1,52 @@
+# XGBoost Classifier
+* * *
+
+Fits the dmlc eXtreme gradient boosting classifier.
+
+## Dependencies
+    xgboost.XGBClassifier
+
+
+Parameters
+----------
+    input_df: pandas.DataFrame {n_samples, n_features+['class', 'group', 'guess']}
+        Input DataFrame for fitting the XGBoost classifier
+    learning_rate: float
+        Shrinks the contribution of each tree by learning_rate
+    max_depth: int
+        Maximum depth of the individual estimators; the maximum depth limits the number of nodes in the tree
+    subsample: float
+        Maximum number of features to use (proportion of total features)
+    min_child_weight: float
+        The minimum weighted fraction of the input samples required to be at a leaf node.
+
+Returns
+-------
+    input_df: pandas.DataFrame {n_samples, n_features+['guess', 'group', 'class', 'SyntheticFeature']}
+        Returns a modified input DataFrame with the guess column updated according to the classifier's predictions.
+        Also adds the classifiers's predictions as a 'SyntheticFeature' column.
+
+
+Example Exported Code
+---------------------
+
+```Python
+import numpy as np
+import pandas as pd
+from sklearn.cross_validation import train_test_split
+from xgboost import XGBClassifier
+
+# NOTE: Make sure that the class is labeled 'class' in the data file
+tpot_data = pd.read_csv('PATH/TO/DATA/FILE', sep='COLUMN_SEPARATOR')
+training_indices, testing_indices = train_test_split(tpot_data.index, stratify=tpot_data['class'].values, train_size=0.75, test_size=0.25)
+
+
+result1 = tpot_data.copy()
+
+# Perform classification with a gradient boosting classifier
+xgbc1 = XGBClassifier(learning_rate=0.0001, n_estimators=500, max_depth=None)
+xgbc1.fit(result1.loc[training_indices].drop('class', axis=1).values, result1.loc[training_indices, 'class'].values)
+
+result1['xgbc1-classification'] = xgbc1.predict(result1.drop('class', axis=1).values)
+
+```

--- a/setup.py
+++ b/setup.py
@@ -45,4 +45,5 @@ This project is hosted at https://github.com/rhiever/tpot
         'Topic :: Scientific/Engineering :: Artificial Intelligence'
     ],
     keywords=['pipeline optimization', 'hyperparameter optimization', 'data science', 'machine learning', 'genetic programming', 'evolutionary computation'],
+    extra_require = {'xgboost': ['xgboost']},
 )

--- a/tests.py
+++ b/tests.py
@@ -25,6 +25,12 @@ from sklearn.feature_selection import RFE, SelectPercentile, f_classif, SelectKB
 from deap import creator
 from tqdm import tqdm
 
+has_xgb = True
+try:
+    from xgboost import XGBClassifier
+except ImportError:
+    has_xgb = False
+
 # Set up the MNIST data set for testing
 mnist_data = load_digits()
 training_features, testing_features, training_classes, testing_classes =\
@@ -955,6 +961,30 @@ def test_passive_aggressive_2():
     pagg.fit(training_features, training_classes)
 
     assert np.array_equal(result['guess'].values, pagg.predict(testing_features))
+
+def test_xgboost():
+     """Ensure that the TPOT xgboost method outputs the same as the xgboost classfier method"""
+
+     tpot_obj = TPOT()
+     result = tpot_obj._xgradient_boosting(training_testing_data, learning_rate=0, max_depth=3)
+     result = result[result['group'] == 'testing']
+
+     xgb = XGBClassifier(n_estimators=500, learning_rate=0.0001, max_depth=3, seed=42)
+     xgb.fit(training_features, training_classes)
+
+     assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
+
+def test_xgboost_2():
+     """Ensure that the TPOT xgboost method outputs the same as the xgboost classfier method when max_depth<1"""
+
+     tpot_obj = TPOT()
+     result = tpot_obj._xgradient_boosting(training_testing_data, learning_rate=0, max_depth=0)
+     result = result[result['group'] == 'testing']
+
+     xgb = XGBClassifier(n_estimators=500, learning_rate=0.0001, max_depth=None, seed=42)
+     xgb.fit(training_features, training_classes)
+
+     assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
 
 
 def test_gradient_boosting():

--- a/tests.py
+++ b/tests.py
@@ -965,64 +965,69 @@ def test_passive_aggressive_2():
 def test_xgboost():
      """Ensure that the TPOT xgboost method outputs the same as the xgboost classfier method"""
 
-     tpot_obj = TPOT()
-     result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=5)
-     result = result[result['group'] == 'testing']
+     if has_xgb:
+        tpot_obj = TPOT()
+        result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=5)
+        result = result[result['group'] == 'testing']
 
-     xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=5)
-     xgb.fit(training_features, training_classes)
+        xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=5)
+        xgb.fit(training_features, training_classes)
 
-     assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
-     
+        assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
+
 
 def test_xgboost_2():
      """Ensure that the TPOT xgboost method outputs the same as the xgboost classfier method when learning_rate > 1"""
 
-     tpot_obj = TPOT()
-     result = tpot_obj._xg_boosting(training_testing_data, learning_rate=3, subsample=0.8, min_child_weight=3, max_depth=5)
-     result = result[result['group'] == 'testing']
+     if has_xgb:
+         tpot_obj = TPOT()
+         result = tpot_obj._xg_boosting(training_testing_data, learning_rate=3, subsample=0.8, min_child_weight=3, max_depth=5)
+         result = result[result['group'] == 'testing']
 
-     xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=1, subsample=0.8, min_child_weight=3, max_depth=5)
-     xgb.fit(training_features, training_classes)
+         xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=1, subsample=0.8, min_child_weight=3, max_depth=5)
+         xgb.fit(training_features, training_classes)
 
-     assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
+         assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
 
 def test_xgboost_3():
      """Ensure that the TPOT xgboost method outputs the same as the xgboost classfier method when subsample == 0"""
 
-     tpot_obj = TPOT()
-     result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0, min_child_weight=3, max_depth=5)
-     result = result[result['group'] == 'testing']
+     if has_xgb:
+         tpot_obj = TPOT()
+         result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0, min_child_weight=3, max_depth=5)
+         result = result[result['group'] == 'testing']
 
-     xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.1, min_child_weight=3, max_depth=5)
-     xgb.fit(training_features, training_classes)
+         xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.1, min_child_weight=3, max_depth=5)
+         xgb.fit(training_features, training_classes)
 
-     assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
-     
+         assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
+
 def test_xgboost_4():
      """Ensure that the TPOT xgboost method outputs the same as the xgboost classfier method when max_depth < 0"""
 
-     tpot_obj = TPOT()
-     result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=0.1)
-     result = result[result['group'] == 'testing']
+     if has_xgb:
+         tpot_obj = TPOT()
+         result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=0.1)
+         result = result[result['group'] == 'testing']
 
-     xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=1)
-     xgb.fit(training_features, training_classes)
+         xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=1)
+         xgb.fit(training_features, training_classes)
 
-     assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
-     
+         assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
+
 def test_xgboost_5():
      """Ensure that the TPOT xgboost method outputs the same as the xgboost classfier method when min_child_weight < 0"""
 
-     tpot_obj = TPOT()
-     result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0.8, min_child_weight=-3 , max_depth=5)
-     result = result[result['group'] == 'testing']
+     if has_xgb:
+         tpot_obj = TPOT()
+         result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0.8, min_child_weight=-3 , max_depth=5)
+         result = result[result['group'] == 'testing']
 
-     xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.8, min_child_weight=0, max_depth=5)
-     xgb.fit(training_features, training_classes)
+         xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.8, min_child_weight=0, max_depth=5)
+         xgb.fit(training_features, training_classes)
 
-     assert np.array_equal(result['guess'].values, xgb.predict(testing_features))     
-     
+         assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
+
 
 def test_gradient_boosting():
     """Ensure that the TPOT GradientBoostingClassifier outputs the same as the sklearn classifier"""

--- a/tests.py
+++ b/tests.py
@@ -966,26 +966,63 @@ def test_xgboost():
      """Ensure that the TPOT xgboost method outputs the same as the xgboost classfier method"""
 
      tpot_obj = TPOT()
-     result = tpot_obj._xgradient_boosting(training_testing_data, learning_rate=0, max_depth=3)
+     result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=5)
      result = result[result['group'] == 'testing']
 
-     xgb = XGBClassifier(n_estimators=500, learning_rate=0.0001, max_depth=3, seed=42)
+     xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=5)
      xgb.fit(training_features, training_classes)
 
      assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
+     
 
 def test_xgboost_2():
-     """Ensure that the TPOT xgboost method outputs the same as the xgboost classfier method when max_depth<1"""
+     """Ensure that the TPOT xgboost method outputs the same as the xgboost classfier method when learning_rate > 1"""
 
      tpot_obj = TPOT()
-     result = tpot_obj._xgradient_boosting(training_testing_data, learning_rate=0, max_depth=0)
+     result = tpot_obj._xg_boosting(training_testing_data, learning_rate=3, subsample=0.8, min_child_weight=3, max_depth=5)
      result = result[result['group'] == 'testing']
 
-     xgb = XGBClassifier(n_estimators=500, learning_rate=0.0001, max_depth=None, seed=42)
+     xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=1, subsample=0.8, min_child_weight=3, max_depth=5)
      xgb.fit(training_features, training_classes)
 
      assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
 
+def test_xgboost_3():
+     """Ensure that the TPOT xgboost method outputs the same as the xgboost classfier method when subsample == 0"""
+
+     tpot_obj = TPOT()
+     result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0, min_child_weight=3, max_depth=5)
+     result = result[result['group'] == 'testing']
+
+     xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.1, min_child_weight=3, max_depth=5)
+     xgb.fit(training_features, training_classes)
+
+     assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
+     
+def test_xgboost_4():
+     """Ensure that the TPOT xgboost method outputs the same as the xgboost classfier method when max_depth < 0"""
+
+     tpot_obj = TPOT()
+     result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=0.1)
+     result = result[result['group'] == 'testing']
+
+     xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=1)
+     xgb.fit(training_features, training_classes)
+
+     assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
+     
+def test_xgboost_5():
+     """Ensure that the TPOT xgboost method outputs the same as the xgboost classfier method when min_child_weight < 0"""
+
+     tpot_obj = TPOT()
+     result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0.8, min_child_weight=-3 , max_depth=5)
+     result = result[result['group'] == 'testing']
+
+     xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.8, min_child_weight=0, max_depth=5)
+     xgb.fit(training_features, training_classes)
+
+     assert np.array_equal(result['guess'].values, xgb.predict(testing_features))     
+     
 
 def test_gradient_boosting():
     """Ensure that the TPOT GradientBoostingClassifier outputs the same as the sklearn classifier"""

--- a/tests.py
+++ b/tests.py
@@ -967,10 +967,10 @@ def test_xgboost():
 
      if has_xgb:
         tpot_obj = TPOT()
-        result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=5)
+        result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0.8, min_child_weight=3, n_estimators=50)
         result = result[result['group'] == 'testing']
 
-        xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=5)
+        xgb = XGBClassifier(max_depth=100, seed=42, learning_rate=0.0001, subsample=0.8, min_child_weight=3, n_estimators=50)
         xgb.fit(training_features, training_classes)
 
         assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
@@ -981,10 +981,10 @@ def test_xgboost_2():
 
      if has_xgb:
          tpot_obj = TPOT()
-         result = tpot_obj._xg_boosting(training_testing_data, learning_rate=3, subsample=0.8, min_child_weight=3, max_depth=5)
+         result = tpot_obj._xg_boosting(training_testing_data, learning_rate=3, subsample=0.8, min_child_weight=3, n_estimators=50)
          result = result[result['group'] == 'testing']
 
-         xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=1, subsample=0.8, min_child_weight=3, max_depth=5)
+         xgb = XGBClassifier(max_depth=100, seed=42, learning_rate=1, subsample=0.8, min_child_weight=3, n_estimators=50)
          xgb.fit(training_features, training_classes)
 
          assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
@@ -994,23 +994,23 @@ def test_xgboost_3():
 
      if has_xgb:
          tpot_obj = TPOT()
-         result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0, min_child_weight=3, max_depth=5)
+         result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0, min_child_weight=3, n_estimators=50)
          result = result[result['group'] == 'testing']
 
-         xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.1, min_child_weight=3, max_depth=5)
+         xgb = XGBClassifier(max_depth=100, seed=42, learning_rate=0.0001, subsample=0.1, min_child_weight=3, n_estimators=50)
          xgb.fit(training_features, training_classes)
 
          assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
 
 def test_xgboost_4():
-     """Ensure that the TPOT xgboost method outputs the same as the xgboost classfier method when max_depth < 0"""
+     """Ensure that the TPOT xgboost method outputs the same as the xgboost classfier method when n_estimators < 0"""
 
      if has_xgb:
          tpot_obj = TPOT()
-         result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=0.1)
+         result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0.8, min_child_weight=3, n_estimators=0.5)
          result = result[result['group'] == 'testing']
 
-         xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.8, min_child_weight=3, max_depth=1)
+         xgb = XGBClassifier(max_depth=100, seed=42, learning_rate=0.0001, subsample=0.8, min_child_weight=3, n_estimators=1)
          xgb.fit(training_features, training_classes)
 
          assert np.array_equal(result['guess'].values, xgb.predict(testing_features))
@@ -1020,10 +1020,10 @@ def test_xgboost_5():
 
      if has_xgb:
          tpot_obj = TPOT()
-         result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0.8, min_child_weight=-3 , max_depth=5)
+         result = tpot_obj._xg_boosting(training_testing_data, learning_rate=0.0001, subsample=0.8, min_child_weight=-3, n_estimators=50)
          result = result[result['group'] == 'testing']
 
-         xgb = XGBClassifier(n_estimators=500, seed=42, learning_rate=0.0001, subsample=0.8, min_child_weight=0, max_depth=5)
+         xgb = XGBClassifier(max_depth=100, seed=42, learning_rate=0.0001, subsample=0.8, min_child_weight=1, n_estimators=50)
          xgb.fit(training_features, training_classes)
 
          assert np.array_equal(result['guess'].values, xgb.predict(testing_features))

--- a/tpot/export_utils.py
+++ b/tpot/export_utils.py
@@ -396,20 +396,22 @@ gbc{OPERATOR_NUM}.fit({OUTPUT_DF}.loc[training_indices].drop('class', axis=1).va
 """.format(OUTPUT_DF=result_name, OPERATOR_NUM=operator_num, LEARNING_RATE=learning_rate, MAX_FEATURES=max_features, MIN_WEIGHT=min_weight)
         
         elif operator_name == '_xg_boosting':
+            
             learning_rate = min(1., max(float(operator[3]), 0.0001))
-            subsample = min(1., max(0., float(operator[4])))
-            min_child_weight = min(0.5, max(0., float(operator[5])))
+            subsample = min(1., max(0.1, float(operator[4])))            
+            min_child_weight = min(100, max(0, int(operator[5])))
+            max_depth = min(100, max(1, int(operator[6])))            
 
             if result_name != operator[2]:
                 operator_text += "\n{OUTPUT_DF} = {INPUT_DF}.copy()".format(OUTPUT_DF=result_name, INPUT_DF=operator[2])
 
             operator_text += """
 # Perform classification with a extreme gradient boosting classifier
-xgbc{OPERATOR_NUM} = XGBClassifier(learning_rate={LEARNING_RATE}, subsample={SUBSAMPLE}, min_child_weight={MIN_WEIGHT}, n_estimators=500)
+xgbc{OPERATOR_NUM} = XGBClassifier(learning_rate={LEARNING_RATE}, subsample={SUBSAMPLE}, min_child_weight={MIN_WEIGHT}, max_depth={MAX_DEPTH}, n_estimators=500)
 xgbc{OPERATOR_NUM}.fit({OUTPUT_DF}.loc[training_indices].drop('class', axis=1).values, {OUTPUT_DF}.loc[training_indices, 'class'].values)
 
 {OUTPUT_DF}['xgbc{OPERATOR_NUM}-classification'] = xgbc{OPERATOR_NUM}.predict({OUTPUT_DF}.drop('class', axis=1).values)
-""".format(OUTPUT_DF=result_name, OPERATOR_NUM=operator_num, LEARNING_RATE=learning_rate, SUBSAMPLE=subsample, MIN_WEIGHT=min_child_weight)
+""".format(OUTPUT_DF=result_name, OPERATOR_NUM=operator_num, LEARNING_RATE=learning_rate, SUBSAMPLE=subsample, MIN_WEIGHT=min_child_weight, MAX_DEPTH=max_depth)
 
         elif operator_name == '_combine_dfs':
             operator_text += '\n# Combine two DataFrames'

--- a/tpot/export_utils.py
+++ b/tpot/export_utils.py
@@ -399,19 +399,19 @@ gbc{OPERATOR_NUM}.fit({OUTPUT_DF}.loc[training_indices].drop('class', axis=1).va
             
             learning_rate = min(1., max(float(operator[3]), 0.0001))
             subsample = min(1., max(0.1, float(operator[4])))            
-            min_child_weight = min(100, max(0, int(operator[5])))
-            max_depth = min(100, max(1, int(operator[6])))            
+            min_child_weight = max(1, int(operator[5]))
+            n_estimators = min(5000, max(1, int(operator[6])))
 
             if result_name != operator[2]:
                 operator_text += "\n{OUTPUT_DF} = {INPUT_DF}.copy()".format(OUTPUT_DF=result_name, INPUT_DF=operator[2])
 
             operator_text += """
 # Perform classification with a extreme gradient boosting classifier
-xgbc{OPERATOR_NUM} = XGBClassifier(learning_rate={LEARNING_RATE}, subsample={SUBSAMPLE}, min_child_weight={MIN_WEIGHT}, max_depth={MAX_DEPTH}, n_estimators=500)
+xgbc{OPERATOR_NUM} = XGBClassifier(learning_rate={LEARNING_RATE}, subsample={SUBSAMPLE}, min_child_weight={MIN_WEIGHT}, max_depth=100, n_estimators={N_ESTIMATORS})
 xgbc{OPERATOR_NUM}.fit({OUTPUT_DF}.loc[training_indices].drop('class', axis=1).values, {OUTPUT_DF}.loc[training_indices, 'class'].values)
 
 {OUTPUT_DF}['xgbc{OPERATOR_NUM}-classification'] = xgbc{OPERATOR_NUM}.predict({OUTPUT_DF}.drop('class', axis=1).values)
-""".format(OUTPUT_DF=result_name, OPERATOR_NUM=operator_num, LEARNING_RATE=learning_rate, SUBSAMPLE=subsample, MIN_WEIGHT=min_child_weight, MAX_DEPTH=max_depth)
+""".format(OUTPUT_DF=result_name, OPERATOR_NUM=operator_num, LEARNING_RATE=learning_rate, SUBSAMPLE=subsample, MIN_WEIGHT=min_child_weight, N_ESTIMATORS=n_estimators)
 
         elif operator_name == '_combine_dfs':
             operator_text += '\n# Combine two DataFrames'

--- a/tpot/tpot.py
+++ b/tpot/tpot.py
@@ -184,7 +184,9 @@ class TPOT(object):
 
         # Terminals
         int_terminals = np.concatenate((np.arange(0, 51, 1),
-                np.arange(60, 110, 10)))
+                np.arange(60, 110, 10),
+                np.arange(120, 1000, 100),
+                np.arange(1100, 2600, 500),))
 
         for val in int_terminals:
             self._pset.addTerminal(val, int)
@@ -792,7 +794,7 @@ class TPOT(object):
             learning_rate=learning_rate, n_estimators=500,
             max_features=max_features, random_state=42, min_weight_fraction_leaf=min_weight)
 
-    def _xg_boosting(self, input_df, learning_rate, subsample, min_child_weight, max_depth):
+    def _xg_boosting(self, input_df, learning_rate, subsample, min_child_weight, n_estimators):
         """Fits the DMLC XGBoost classifier
 
         Parameters
@@ -803,8 +805,10 @@ class TPOT(object):
             Shrinks the contribution of each tree by learning_rate
         subsample: float
             Maximum number of features to use (proportion of total features)
-        min_child_weight: float
+        min_child_weight: int
             The minimum weighted fraction of the input samples required to be at a leaf node.
+        n_estimators: int
+            The number of estimators (boosting rounds) to perform
 
         Returns
         -------
@@ -815,13 +819,13 @@ class TPOT(object):
         """
         learning_rate = min(1., max(learning_rate, 0.0001))        
         subsample = min(1., max(0.1, subsample))    
-        max_depth = min(100, max(1, max_depth))    
+        n_estimators = min(5000, max(1, n_estimators))
         # xgboost docs say min_child_weight can range from o to inifity
-        min_child_weight = max(0, min_child_weight)
+        min_child_weight = max(1, min_child_weight)
         
         return self._train_model_and_predict(input_df, XGBClassifier,
-            learning_rate=learning_rate, n_estimators=500,
-            subsample=subsample, min_child_weight=min_child_weight, seed=42, max_depth=max_depth)
+            learning_rate=learning_rate, n_estimators=n_estimators,
+            subsample=subsample, min_child_weight=min_child_weight, seed=42, max_depth=100)
 
     def _train_model_and_predict(self, input_df, model, **kwargs):
         """Fits an arbitrary sklearn classifier model with a set of keyword parameters


### PR DESCRIPTION
## What does this PR do?
The objective of this PR is to put XGBoost back in TPOT as an Optional dependency, as discussed on issue #154 


## Where should the reviewer start?
I've brought the documentation back from prior commits and added:
- checks to see if xgboost is present
- tests to new xgboost parameters
- ability to export xgboost operator that are part of a pipeline


## How should this PR be tested?
All nose tests (including new ones) are ok on my machine.
Tried running a toy test with just _xgb_boosting as a primitive in TPOT._pset and all was fine.

```
from tpot import TPOT
from sklearn.datasets import load_digits
from sklearn.cross_validation import train_test_split

digits = load_digits()
X_train, X_test, y_train, y_test = train_test_split(digits.data, digits.target,
                                                    train_size=0.75, test_size=0.25)

tpot = TPOT(generations=3, verbosity=2, population_size=5)
tpot.fit(X_train, y_train)
print(tpot.score(X_test, y_test))
tpot.export('tpot_mnist_pipeline.py')
```

## Any background context you want to provide?

Not really...

## What are the relevant issues?

Issue in #154 

## Screenshots (if appropriate)



## Questions:
