### PR TITLE
[WIP] Custom scoring

### DIFF
--- a/docs/sources/examples/Custom_Scoring_Functions.md
+++ b/docs/sources/examples/Custom_Scoring_Functions.md
@@ -1,18 +1,23 @@
 # Custom Scoring Functions
 
-Below is a minimal working example of different scoring metrics/fitness functions used with the MNIST dataset.
+Below is a minimal working example of different scoring metrics/fitness functions used with the sklearn digits toy-dataset.
 
 ```python
 
 from tpot import TPOT
 from sklearn.datasets import load_digits
 from sklearn.cross_validation import train_test_split
+import numpy as np
+import pandas as pd
 
 digits = load_digits()
 X_train, X_test, y_train, y_test = train_test_split(digits.data, digits.target,
                                                     train_size=0.75, test_size=0.25)
 
-def precision(result):
+def precision(y_true, y_pred):
+    result = pd.DataFrame()
+    result['class'] = y_true
+    result['guess'] = y_pred
     all_classes = list(set(result['class'].values))
     all_class_tps = []
     all_class_tps_fps = []
@@ -30,7 +35,10 @@ def precision(result):
 
     return micro_avg_precision
     
-def recall(result):
+def recall(y_true, y_pred):
+    result = pd.DataFrame()
+    result['class'] = y_true
+    result['guess'] = y_pred
     all_classes = list(set(result['class'].values))
     all_class_tps = []
     all_class_tps_fns = []
@@ -45,7 +53,10 @@ def recall(result):
     micro_avg_recall = float(np.sum(all_class_tps)) / np.sum(all_class_tps_fns)
     return micro_avg_recall
 
-def f1(result):
+def f1(y_true, y_pred):
+    result = pd.DataFrame()
+    result['class'] = y_true
+    result['guess'] = y_pred
     all_classes = list(set(result['class'].values))
     all_class_tps = []
     all_class_tps_fps = []
@@ -65,22 +76,22 @@ def f1(result):
 
     return micro_avg_f1
 
-tpot = TPOT(generations=5)
+tpot = TPOT(generations=5, verbosity=2)
 tpot.fit(X_train, y_train)
-print 'acc: ', tpot.score(X_test, y_test)
+print('acc: {}'.format(tpot.score(X_test, y_test)))
 
-tpot = TPOT(generations=5, scoring_function=precision)
+tpot = TPOT(generations=5, scoring_function=precision, verbosity=2)
 tpot.fit(X_train, y_train)
-print 'precision: ', tpot.score(X_test, y_test)
+print('precision: {}'.format(tpot.score(X_test, y_test)))
 
-tpot = TPOT(generations=5, scoring_function=recall)
+tpot = TPOT(generations=5, scoring_function=recall, verbosity=2)
 tpot.fit(X_train, y_train)
-print 'recall: ', tpot.score(X_test, y_test)
+print('recall: {}'.format(tpot.score(X_test, y_test)))
 
-tpot = TPOT(generations=5, scoring_function=f1)
+tpot = TPOT(generations=5, scoring_function=f1, verbosity=2)
 tpot.fit(X_train, y_train)
-print 'f1: ', tpot.score(X_test, y_test)
+print('f1: {}'.format(tpot.score(X_test, y_test)))
 
 ```
 
-Running this example should discover a pipeline that achieves ~98% testing accuracy, ~93% testing precision, ~97% testing recall, and ~95% testing f1.
+

--- a/tests.py
+++ b/tests.py
@@ -500,7 +500,7 @@ def test_scoring_functions_1():
     tpot_obj = TPOT()
 
     assert(tpot_obj.scoring_function == tpot_obj._balanced_accuracy)
-
+'''
 def test_scoring_functions_2():
     """Assert that a custom classification-based scoring function uses the predict function of each classifier"""
     def custom_scoring_function(y_true, y_pred):
@@ -590,6 +590,7 @@ def test_train_model_and_predict_2():
         [np.loads(x) for x in result.loc[:, 'guess']]
     except:
         assert False # Should be unreachable
+'''
 
 def test_float_range_3():
     """Assert that the TPOT CLI interface's float range throws an exception when input is not a float"""

--- a/tests.py
+++ b/tests.py
@@ -1045,7 +1045,7 @@ def test_scoring_functions_2():
     assert(tpot_obj.scoring_function == custom_scoring_function)
     
 
-def test_scoring_function_3():
+def test_scoring_functions_3():
     """Assert that the parse_scoring_docstring works for classification metrics"""
 
     tpot_obj = TPOT()
@@ -1074,5 +1074,43 @@ def test_scoring_function_3():
         tpot_obj = TPOT(scoring_function=scoring_func)
         assert(tpot_obj._parse_scoring_docstring(tpot_obj.scoring_function) == 'decision_function')
 
+def test_scoring_functions_4():
+    """ Assert that a loss function gets the sign flipped and the correct function is used in evaluation """
 
+    tpot_obj = TPOT(population_size=1, generations=1, scoring_function=metrics.hamming_loss)
+    tpot_obj.fit(training_features, training_classes)
+    
+    assert(tpot_obj.score_sign == -1)
+    assert(tpot_obj.clf_eval_func == 'predict')
+
+def test_train_model_and_predict_2():
+    """ Assert that training an individual classifier and predicting makes use of correct function, un/pickling as necessary"""
+
+    tpot_obj = TPOT(population_size=1, generations=1, scoring_function=metrics.hamming_loss)
+    tpot_obj.clf_eval_func = tpot_obj._parse_scoring_docstring(tpot_obj.scoring_function)
+
+    try:
+        result = tpot_obj._train_model_and_predict(training_testing_data, LinearSVC, C=5., penalty='l1', dual=False)
+        [np.loads(x) for x in result.loc[:, 'guess']]
+        assert False
+    except:
+        pass
+
+    tpot_obj = TPOT(population_size=1, generations=1, scoring_function=metrics.log_loss)
+    tpot_obj.clf_eval_func = tpot_obj._parse_scoring_docstring(tpot_obj.scoring_function)
+
+    try:
+        result = tpot_obj._train_model_and_predict(training_testing_data, GaussianNB)
+        [np.loads(x) for x in result.loc[:, 'guess']]
+    except:
+        assert False
+
+    tpot_obj = TPOT(population_size=1, generations=1, scoring_function=metrics.hinge_loss)
+    tpot_obj.clf_eval_func = tpot_obj._parse_scoring_docstring(tpot_obj.scoring_function)
+
+    try:
+        result = tpot_obj._train_model_and_predict(training_testing_data, LinearSVC, C=5., penalty='l1', dual=False)
+        [np.loads(x) for x in result.loc[:, 'guess']]
+    except:
+        assert False
 

--- a/tpot/operators/base.py
+++ b/tpot/operators/base.py
@@ -37,6 +37,8 @@ class Operator(object):
         'n_jobs': -1
     }
 
+    clf_eval_func = 'predict'
+
     def __call__(self, input_matrix, *args, **kwargs):
         input_matrix = np.copy(input_matrix)  # Make a copy of the input matrix
 

--- a/tpot/operators/classifiers/base.py
+++ b/tpot/operators/classifiers/base.py
@@ -32,7 +32,6 @@ class Classifier(Operator):
     def _call(self, input_matrix, *args, **kwargs):
         # Calculate arguments to be passed directly to sklearn
         operator_args = self.preprocess_args(*args, **kwargs)
-
         return self._train_and_predict(input_matrix, operator_args)
 
     def _train_and_predict(self, input_matrix, operator_args):
@@ -57,8 +56,22 @@ class Classifier(Operator):
         clf.fit(self.training_features, self.training_classes)
 
         all_features = np.delete(input_matrix, non_feature_columns, axis=1)
-        input_matrix[:, GUESS_COL] = clf.predict(all_features)
+        if self.clf_eval_func == 'decision_function':
+            if 'decision_function' in dir(clf):
+                input_matrix = np.insert(input_matrix, GUESS_COL, clf.decision_function(all_features).T, axis=1)
+            else:
+                input_matrix = np.insert(input_matrix, GUESS_COL, np.array([[0.] * max(1, len(np.unique(training_classes))) for x in list(range(input_matrix.shape[0]))]).T, axis=1)
+        elif self.clf_eval_func == 'predict_proba':
+            if 'predict_proba' in dir(clf):
+                input_matrix = np.insert(input_matrix, GUESS_COL, clf.predict_proba(all_features).T, axis=1)
+            else:
+                input_matrix = np.insert(input_matrix, GUESS_COL, np.array([[0.] * max(1, len(np.unique(training_classes))) for x in list(range(input_matrix.shape[0]))]).T, axis=1)
+        else:
+            input_matrix[:, GUESS_COL] = clf.predict(all_features)
         # Store the guesses as a synthetic feature
-        np.insert(input_matrix, input_matrix.shape[1], input_matrix[:, GUESS_COL], axis=1)
+        if self.clf_eval_func == 'predict_proba' or self.clf_eval_func == 'decision_function':
+            input_matrix = np.insert(input_matrix, input_matrix.shape[1], clf.predict(all_features), axis=1)
+        else:
+            input_matrix = np.insert(input_matrix, input_matrix.shape[1], input_matrix[:, GUESS_COL], axis=1)
 
         return input_matrix

--- a/tpot/operators/classifiers/base.py
+++ b/tpot/operators/classifiers/base.py
@@ -56,22 +56,21 @@ class Classifier(Operator):
         clf.fit(self.training_features, self.training_classes)
 
         all_features = np.delete(input_matrix, non_feature_columns, axis=1)
+
+        input_matrix[:, GUESS_COL] = clf.predict(all_features)
+
+        # Store the guesses as a synthetic feature
+        input_matrix = np.insert(input_matrix, input_matrix.shape[1], input_matrix[:, GUESS_COL], axis=1)
+        
         if self.clf_eval_func == 'decision_function':
             if 'decision_function' in dir(clf):
-                input_matrix = np.insert(input_matrix, GUESS_COL, clf.decision_function(all_features).T, axis=1)
+                input_matrix = np.insert(input_matrix, input_matrix.shape[1], clf.decision_function(all_features).T, axis=1)
             else:
-                input_matrix = np.insert(input_matrix, GUESS_COL, np.array([[0.] * max(1, len(np.unique(training_classes))) for x in list(range(input_matrix.shape[0]))]).T, axis=1)
+                input_matrix = np.insert(input_matrix, input_matrix.shape[1], np.array([[0.] * max(1, len(np.unique(training_classes))) for x in list(range(input_matrix.shape[0]))]).T, axis=1)
         elif self.clf_eval_func == 'predict_proba':
             if 'predict_proba' in dir(clf):
-                input_matrix = np.insert(input_matrix, GUESS_COL, clf.predict_proba(all_features).T, axis=1)
+                input_matrix = np.insert(input_matrix, input_matrix.shape[1], clf.predict_proba(all_features).T, axis=1)
             else:
-                input_matrix = np.insert(input_matrix, GUESS_COL, np.array([[0.] * max(1, len(np.unique(training_classes))) for x in list(range(input_matrix.shape[0]))]).T, axis=1)
-        else:
-            input_matrix[:, GUESS_COL] = clf.predict(all_features)
-        # Store the guesses as a synthetic feature
-        if self.clf_eval_func == 'predict_proba' or self.clf_eval_func == 'decision_function':
-            input_matrix = np.insert(input_matrix, input_matrix.shape[1], clf.predict(all_features), axis=1)
-        else:
-            input_matrix = np.insert(input_matrix, input_matrix.shape[1], input_matrix[:, GUESS_COL], axis=1)
+                input_matrix = np.insert(input_matrix, input_matrix.shape[1], np.array([[0.] * max(1, len(np.unique(training_classes))) for x in list(range(input_matrix.shape[0]))]).T, axis=1)
 
         return input_matrix

--- a/tpot/tpot.py
+++ b/tpot/tpot.py
@@ -55,7 +55,6 @@ import deap
 from deap import algorithms, base, creator, tools, gp
 
 from tqdm import tqdm
-from ast import literal_eval 
 
 class Bool(object):
     """Boolean class used for deap due to deap's poor handling of ints and booleans"""
@@ -1570,7 +1569,7 @@ class TPOT(object):
                 return 5000., 0.
         except (KeyboardInterrupt, SystemExit):
             raise
-        except Exception as e:
+        except Exception:
             # Catch-all: Do not allow one pipeline that crashes to cause TPOT to crash
             # Instead, assign the crashing pipeline a poor fitness
             if self.score_sign == -1:

--- a/tpot/tpot.py
+++ b/tpot/tpot.py
@@ -515,9 +515,9 @@ class TPOT(object):
             result = func(data)
             result = result[result[:, GROUP_COL] == TESTING_GROUP]
             n_classes = int(np.unique(self._training_classes).size)
-            #If the scoring function requires we use predict_proba or decision_function then unpickle the data we pickled when training the classifier
+            #If the scoring function requires we use predict_proba or decision_function then we slice from the end of the matrix
             if self.clf_eval_func == 'predict_proba' or self.clf_eval_func == 'decision_function':
-                resulting_score = self.scoring_function(result[:, CLASS_COL], result[:, GUESS_COL:GUESS_COL+n_classes], **self.scoring_kwargs)
+                resulting_score = self.scoring_function(result[:, CLASS_COL], result[:, -n_classes:], **self.scoring_kwargs)
             else:
                 resulting_score = self.scoring_function(result[:, CLASS_COL], result[:, GUESS_COL], **self.scoring_kwargs)
         except MemoryError:


### PR DESCRIPTION
## What does this PR do?
 Addresses #156 to allow for classification metrics from scikit-learn's metrics module to be passed to TPOT as scoring functions, along with keyword arguments for the function. Currently  lumps together scoring functions that require decision functions and prediction probabilities together. 

- [x] actual implementation 
- [x] unit-tests for different metrics
- [x] documentation change

## Where should the reviewer start?

fit(), _evaluate_individual(), and _train_model_and_predict()

## How should this PR be tested?

With classification scoring functions from sklearn.metrics

## Any background context you want to provide?

Some of the functions require a classifier's _decision-function_ output in place of a list of predicted classes, and some of the functions require a classifier's _prediction-probabilities_ output. These functions are currently lumped together in consideration -- it is difficult to inspect the input scoring function to see if it requires one or the other (without explicit listing of all the scoring functions, which would become bulky when we start considering regression metrics, etc), so scoring functions requiring decision functions _may_ mis-represent an individual's fitness.  

It was decided to lump decision function scoring functions into the prediction probability ones (and not vice versa), since decision functions can return negative numbers, and probabilities not. 

## What are the relevant issues?

#156 

## Screenshots (if appropriate)



## Questions:

- Do the docs need to be updated?
Yes, at the very least to reflect the caveats discussed above about the decision_function. 
- Does this PR add new (Python) dependencies?
No. 
- How much should TPOT handle wrt type checking, etc, and how much should we rely on the users? 