### PR TITLE
Add SelectFromModel feature selector (Fixes #212)

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -201,8 +201,7 @@ def test_generate_pipeline_code():
             ['GradientBoostingClassifier',
                 'input_matrix',
                 38.0,
-                0.87,
-                0.5],
+                0.87],
             ['GaussianNB',
                 ['ZeroCount',
                     'input_matrix']]],
@@ -212,7 +211,7 @@ def test_generate_pipeline_code():
     expected_code = """make_pipeline(
     make_union(
         make_union(VotingClassifier(estimators=[('branch',
-            GradientBoostingClassifier(learning_rate=1.0, max_features=1.0, min_weight_fraction_leaf=0.5, n_estimators=500)
+            GradientBoostingClassifier(learning_rate=1.0, max_features=1.0, n_estimators=500)
         )]), FunctionTransformer(lambda X: X)),
         make_union(VotingClassifier(estimators=[('branch',
             make_pipeline(
@@ -256,7 +255,7 @@ def test_export_pipeline():
     """Assert that exported_pipeline() generated a compile source file as expected given a fixed pipeline"""
     tpot_obj = TPOT()
     pipeline = creator.Individual.\
-        from_string("KNeighborsClassifier(CombineDFs(GradientBoostingClassifier(input_matrix, 38.0, 0.87, 0.5), RFE(input_matrix, 0.17999999999999999)), 18, 33)", tpot_obj._pset)
+        from_string("KNeighborsClassifier(CombineDFs(GradientBoostingClassifier(input_matrix, 38.0, 0.87), RFE(input_matrix, 0.17999999999999999)), 18, 33)", tpot_obj._pset)
 
     expected_code = """import numpy as np
 
@@ -277,7 +276,7 @@ training_features, testing_features, training_classes, testing_classes = \\
 exported_pipeline = make_pipeline(
     make_union(
         make_union(VotingClassifier(estimators=[('branch',
-            GradientBoostingClassifier(learning_rate=1.0, max_features=1.0, min_weight_fraction_leaf=0.5, n_estimators=500)
+            GradientBoostingClassifier(learning_rate=1.0, max_features=1.0, n_estimators=500)
         )]), FunctionTransformer(lambda X: X)),
         RFE(estimator=SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0,
           decision_function_shape=None, degree=3, gamma='auto', kernel='linear',

--- a/tpot/operators/classifiers/gradient_boosting.py
+++ b/tpot/operators/classifiers/gradient_boosting.py
@@ -31,25 +31,21 @@ class TPOTGradientBoosting(Classifier):
         Shrinks the contribution of each tree by learning_rate
     max_features: float
         Maximum number of features to use (proportion of total features)
-    min_weight_fraction_leaf: float
-        The minimum weighted fraction of the input samples required to be at a leaf node.
 
     """
     import_hash = {'sklearn.ensemble': ['GradientBoostingClassifier']}
     sklearn_class = GradientBoostingClassifier
-    arg_types = (float, float, float)
+    arg_types = (float, float)
 
     def __init__(self):
         pass
 
-    def preprocess_args(self, learning_rate, max_features, min_weight_fraction_leaf):
+    def preprocess_args(self, learning_rate, max_features):
         learning_rate = min(1., max(learning_rate, 0.0001))
         max_features = min(1., max(0., learning_rate))
-        min_weight = min(0.5, max(0., min_weight_fraction_leaf))
 
         return {
             'learning_rate': learning_rate,
             'max_features': max_features,
-            'min_weight_fraction_leaf': min_weight,
             'n_estimators': 500
         }

--- a/tpot/operators/selectors/__init__.py
+++ b/tpot/operators/selectors/__init__.py
@@ -24,3 +24,4 @@ from .select_fwe import *
 from .select_kbest import *
 from .select_percentile import *
 from .variance_threshold import *
+from .select_from_model import *

--- a/tpot/operators/selectors/select_from_model.py
+++ b/tpot/operators/selectors/select_from_model.py
@@ -18,30 +18,42 @@ with the TPOT library. If not, see http://www.gnu.org/licenses/.
 
 """
 
-from .base import Classifier
+from .base import Selector
+from sklearn.feature_selection import SelectFromModel
 from sklearn.ensemble import ExtraTreesClassifier
 
 
-class TPOTExtraTreesClassifier(Classifier):
-    """Fits an Extra Trees Classifier
+class TPOTSelectFromModel(Selector):
+    """Uses scikit-learn's ExtraTreesClassifier combined with SelectFromModel
+    to transform the feature set.
 
     Parameters
     ----------
+    threshold: float
+        Features whose importance is greater or equal are kept while the others
+        are discarded.
     criterion: int
+        For the ExtraTreesClassifier:
         Integer that is used to select from the list of valid criteria,
         either 'gini', or 'entropy'
     max_features: float
+        For the ExtraTreesClassifier:
         The number of features to consider when looking for the best split
 
     """
-    import_hash = {'sklearn.ensemble': ['ExtraTreesClassifier']}
-    sklearn_class = ExtraTreesClassifier
-    arg_types = (int, float)
+    import_hash = {
+        'sklearn.feature_selection': ['SelectFromModel'],
+        'sklearn.ensemble':          ['ExtraTreesClassifier']
+    }
+    sklearn_class = SelectFromModel
+    arg_types = (float, int, float)
 
     def __init__(self):
         pass
 
-    def preprocess_args(self, criterion, max_features):
+    def preprocess_args(self, threshold, criterion, max_features):
+        threshold = min(1., max(0., threshold))
+
         # Select criterion string from list of valid parameters
         criterion_values = ['gini', 'entropy']
         criterion_selection = criterion_values[criterion % len(criterion_values)]
@@ -49,7 +61,6 @@ class TPOTExtraTreesClassifier(Classifier):
         max_features = min(1., max(0., max_features))
 
         return {
-            'criterion': criterion_selection,
-            'max_features': max_features,
-            'n_estimators': 500
+            'estimator': ExtraTreesClassifier(criterion=criterion_selection, max_features=max_features),
+            'threshold': threshold
         }

--- a/tpot/tpot.py
+++ b/tpot/tpot.py
@@ -457,7 +457,7 @@ class TPOT(object):
         """
 
         try:
-            # Transform the tree expression in a callable function
+            # Transform the tree expression into an sklearn pipeline
             sklearn_pipeline = self._toolbox.compile(expr=individual)
 
             # Count the number of pipeline operators as a measure of pipeline
@@ -481,6 +481,8 @@ class TPOT(object):
         except Exception:
             # Catch-all: Do not allow one pipeline that crashes to cause TPOT
             # to crash. Instead, assign the crashing pipeline a poor fitness
+            # import traceback
+            # traceback.print_exc()
             return 5000., 0.
         finally:
             if not self.pbar.disable:


### PR DESCRIPTION
## What does this PR do?

* Adds the SelectFromModel feature selector, using ExtraTreesClassifiers' feature importances

I'm not sure exactly what min and max should be set on threshold for SelectFromModel. Right now I have it set to be in the range of 0. to 1.0

## Where should the reviewer start?

`tpot/operators/selectors/select_from_model.py`

## What are the relevant issues?

#212 
