### PR TITLE
cross_val_score scoring_function support

### DIFF
--- a/docs/sources/using.md
+++ b/docs/sources/using.md
@@ -60,8 +60,8 @@ TPOT offers several arguments that can be provided at the command line:
 <tr>
 <td>-scoring</td>
 <td>SCORING_FN</td>
-<td>"accuracy", "adjusted_rand_score", "average_precision", "f1", "f1_macro", "f1_micro", "f1_samples", "f1_weighted", "precision", "precision_macro", "precision_micro", "precision_samples", "precision_weighted", "recall", "recall_macro", "recall_micro", "recall_samples", "recall_weighted", "roc_auc"</td>
-<td>Function used to evaluate the goodness of a given pipeline for the classification problem. By default, balanced class accuracy is used. TPOT assumes that this scoring function should be maximized, i.e., higher is better.</td>
+<td>"accuracy", "adjusted_rand_score", "average_precision", "f1", "f1_macro", "f1_micro", "f1_samples", "f1_weighted", "precision", "precision_macro", "precision_micro", "precision_samples", "precision_weighted", "recall", "recall_macro", "recall_micro", "recall_samples", "recall_weighted", "roc_auc", "log_loss"</td>
+<td>Function used to evaluate the goodness of a given pipeline for the classification problem. By default, balanced class accuracy is used. TPOT assumes that any function with "error" or "loss" in the name is meant to be minimized, whereas any other functions will be maximized.</td>
 </tr>
 <tr>
 <td>-maxtime</td>
@@ -157,8 +157,8 @@ Note that you can pass several parameters to the TPOT instantiation call:
 </tr>
 <tr>
 <td>scoring_function</td>
-<td>"accuracy", "adjusted_rand_score", "average_precision", "f1", "f1_macro", "f1_micro", "f1_samples", "f1_weighted", "log_loss", "precision", "precision_macro", "precision_micro", "precision_samples", "precision_weighted", "r2", "recall", "recall_macro", "recall_micro", "recall_samples", "recall_weighted", "roc_auc"</td>
-<td>Function used to evaluate the goodness of a given pipeline for the classification problem. By default, balanced class accuracy is used. TPOT assumes that this scoring function should be maximized, i.e., higher is better.</td>
+<td>"accuracy", "adjusted_rand_score", "average_precision", "f1", "f1_macro", "f1_micro", "f1_samples", "f1_weighted", "precision", "precision_macro", "precision_micro", "precision_samples", "precision_weighted", "recall", "recall_macro", "recall_micro", "recall_samples", "recall_weighted", "roc_auc", "log_loss" or a callable function with signature <b>scorer(estimator, X, y)</b></td>
+<td>Function used to evaluate the goodness of a given pipeline for the classification problem. By default, balanced class accuracy is used. TPOT assumes that any function with "error" or "loss" in the name is meant to be minimized, whereas any other functions will be maximized. See the section on <a href="#scoringfunctions">scoring functions</a> for more details.</td>
 </tr>
 <tr>
 <td>max_time_mins</td>
@@ -225,3 +225,17 @@ pipeline_optimizer.export('tpot_exported_pipeline.py')
 Once this code finishes running, `tpot_exported_pipeline.py` will contain the Python code for the optimized pipeline.
 
 Check our [examples](examples/MNIST_Example/) to see TPOT applied to some specific data sets.
+
+<a name="scoringfunctions"></a>
+### Scoring Functions
+
+TPOT makes use of `sklearn.cross_validation.cross_val_score`, and as such has the same support for scoring functions. There are two ways to make use of scoring functions with TPOT:
+
+1. You can pass in a string from the list described in the table above. Any other strings will cause internal issues that may break your code down the line.
+2. You can pass in a function with the signature `scorer(estimator, X, y)` that takes in a scikit-learn estimator (so in TPOT's case, a pipeline that you can call methods like `predict()` on. To do this, you should implement your own function. See the example below for further explanation.
+
+```Python
+def accuracy(estimator, X, y):
+    y_pred = estimator.predict(X)
+    return float(sum(y_pred == y)) / len(y)
+```

--- a/tests.py
+++ b/tests.py
@@ -71,14 +71,11 @@ def test_init_max_time_mins():
 def test_get_params():
     """Assert that get_params returns the exact dictionary of parameters used by TPOT"""
     
-    def dummy_func(est, x, y):
-        return 1.0
-    
     kwargs = {
         'population_size': 500,
         'generations': 1000,
         'verbosity': 1,
-        'scoring_function': dummy_func
+        'scoring_function': 'foobar'
     }
 
     tpot_obj = TPOT(**kwargs)

--- a/tests.py
+++ b/tests.py
@@ -70,11 +70,15 @@ def test_init_max_time_mins():
 
 def test_get_params():
     """Assert that get_params returns the exact dictionary of parameters used by TPOT"""
+    
+    def dummy_func(est, x, y):
+        return 1.0
+    
     kwargs = {
         'population_size': 500,
         'generations': 1000,
         'verbosity': 1,
-        'scoring_function': 'foobar'
+        'scoring_function': dummy_func
     }
 
     tpot_obj = TPOT(**kwargs)

--- a/tests.py
+++ b/tests.py
@@ -49,7 +49,7 @@ def test_init_custom_parameters():
     assert tpot_obj.mutation_rate == 0.05
     assert tpot_obj.crossover_rate == 0.9
     assert tpot_obj.scoring_function == 'log_loss'
-    assert tpot_obj._scoring_sign == 0
+    assert tpot_obj._positive_scoring == 0
     assert tpot_obj.num_cv_folds == 10
     assert tpot_obj.max_time_mins is None
     assert tpot_obj.verbosity == 1

--- a/tests.py
+++ b/tests.py
@@ -20,6 +20,7 @@ from datetime import datetime
 
 from sklearn.datasets import load_digits
 from sklearn.cross_validation import train_test_split
+from sklearn.metrics import get_scorer
 
 from deap import creator
 from tqdm import tqdm
@@ -36,12 +37,9 @@ random.seed(42)
 def test_init_custom_parameters():
     """Assert that the TPOT instantiator stores the TPOT variables properly"""
 
-    def dummy_scoring_func(foo, bar):
-        return
-
     tpot_obj = TPOT(population_size=500, generations=1000,
                     mutation_rate=0.05, crossover_rate=0.9,
-                    scoring_function=dummy_scoring_func,
+                    scoring_function='log_loss',
                     num_cv_folds=10,
                     verbosity=1, random_state=42,
                     disable_update_check=True)
@@ -50,7 +48,8 @@ def test_init_custom_parameters():
     assert tpot_obj.generations == 1000
     assert tpot_obj.mutation_rate == 0.05
     assert tpot_obj.crossover_rate == 0.9
-    assert tpot_obj.scoring_function == dummy_scoring_func
+    assert tpot_obj.scoring_function == get_scorer('log_loss')
+    assert tpot_obj._scoring_sign == -1
     assert tpot_obj.num_cv_folds == 10
     assert tpot_obj.max_time_mins is None
     assert tpot_obj.verbosity == 1

--- a/tests.py
+++ b/tests.py
@@ -48,8 +48,8 @@ def test_init_custom_parameters():
     assert tpot_obj.generations == 1000
     assert tpot_obj.mutation_rate == 0.05
     assert tpot_obj.crossover_rate == 0.9
-    assert tpot_obj.scoring_function == get_scorer('log_loss')
-    assert tpot_obj._scoring_sign == -1
+    assert tpot_obj.scoring_function == 'log_loss'
+    assert tpot_obj._scoring_sign == 0
     assert tpot_obj.num_cv_folds == 10
     assert tpot_obj.max_time_mins is None
     assert tpot_obj.verbosity == 1

--- a/tpot/tpot.py
+++ b/tpot/tpot.py
@@ -156,7 +156,7 @@ class TPOT(BaseEstimator):
             if hasattr(scoring_function, '__call__'):
                 scoring_function_name = scoring_function.__name__
             else:
-                scoring_function = get_scorer(scoring_function)
+                get_scorer(scoring_function)
             if any([x in scoring_function_name for x in ['error', 'loss']]):
                 self._scoring_sign = 0
         

--- a/tpot/tpot.py
+++ b/tpot/tpot.py
@@ -36,7 +36,7 @@ from sklearn.cross_validation import train_test_split, cross_val_score
 from sklearn.pipeline import make_pipeline, make_union
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.ensemble import VotingClassifier
-from sklearn.metrics import get_scorer, SCORERS
+from sklearn.metrics import get_scorer
 
 from update_checker import update_check
 
@@ -155,11 +155,8 @@ class TPOT(object):
         if scoring_function is None:
             self.scoring_function = self._balanced_accuracy
         else:
-            if not isinstance(scoring_function, str): 
-                raise ValueError('{} is not a valid scoring value. Valid options are {}'.format(scoring_function, sorted(SCORERS.keys())))
             self.scoring_function = get_scorer(scoring_function)
-            if any([x in scoring_function for x in ['error', 'loss']]): 
-                self._scoring_sign = -1.
+            if any([x in scoring_function for x in ['error', 'loss']]): self._scoring_sign = -1.
         
         self.num_cv_folds = num_cv_folds
 

--- a/tpot/tpot.py
+++ b/tpot/tpot.py
@@ -37,7 +37,6 @@ from sklearn.cross_validation import train_test_split, cross_val_score
 from sklearn.pipeline import make_pipeline, make_union
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.ensemble import VotingClassifier
-from sklearn.metrics import get_scorer, make_scorer
 
 from update_checker import update_check
 
@@ -155,8 +154,6 @@ class TPOT(BaseEstimator):
             scoring_function_name = scoring_function
             if hasattr(scoring_function, '__call__'):
                 scoring_function_name = scoring_function.__name__
-            else:
-                get_scorer(scoring_function)
             if any([x in scoring_function_name for x in ['error', 'loss']]):
                 self._scoring_sign = 0
         

--- a/tpot/tpot.py
+++ b/tpot/tpot.py
@@ -36,7 +36,7 @@ from sklearn.cross_validation import train_test_split, cross_val_score
 from sklearn.pipeline import make_pipeline, make_union
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.ensemble import VotingClassifier
-from sklearn.metrics import get_scorer
+from sklearn.metrics import get_scorer, SCORERS
 
 from update_checker import update_check
 
@@ -155,8 +155,11 @@ class TPOT(object):
         if scoring_function is None:
             self.scoring_function = self._balanced_accuracy
         else:
+            if not isinstance(scoring_function, str): 
+                raise ValueError('{} is not a valid scoring value. Valid options are {}'.format(scoring_function, sorted(SCORERS.keys())))
             self.scoring_function = get_scorer(scoring_function)
-            if any([x in scoring_function for x in ['error', 'loss']]): self._scoring_sign = -1.
+            if any([x in scoring_function for x in ['error', 'loss']]): 
+                self._scoring_sign = -1.
         
         self.num_cv_folds = num_cv_folds
 


### PR DESCRIPTION
## What does this PR do?

1. Addresses #238, allowing use for compatible loss/error functions and having TPOT takes the best pipeline when using log_loss. 
2. Uses sklearn's get_scorer function to validate strings passed in a scoring_function are valid (for cross_val_score), and restricts use of custom functions. 
3. Tweaks the instantiator test to reflect the above changes. 

## Where should the reviewer start?

tpot.py:__init__()
tpot.py:fit()
tpot.py:_evaluate_individual()

## How should this PR be tested?

Making sure that the fitted pipelines 

## Any background context you want to provide?

1. Some scoring functions implemented in sklearn only allow for binary classification, causing pipelines to raise exceptions if the data is multiclass.
2.  `log_loss` needs predict_proba support. This may restrict the classifier operators used in the final pipelines to those that support that functionality. 

## What are the relevant issues?

#238 

## Screenshots (if appropriate)

## Questions:

- Do the docs need to be updated?
No, as the docs already reflect that strings should be passed in as the scoring_function parameter.
- Does this PR add new (Python) dependencies?
No