### PR TITLE
Add XGBoost as an optional dependency (Fixes #152)

### DIFF
--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -38,15 +38,17 @@ else
     conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
         numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
         scikit-learn=$SKLEARN_VERSION \
-	cython
+    cython
 fi
 
 source activate testenv
 
 if [[ "$LATEST" == "true" ]]; then
     pip install deap
+    pip install xgboost
 else
     pip install deap==$DEAP_VERSION
+    pip install xgboost==$XGBOOST_VERSION
 fi
 
 pip install update_checker
@@ -62,6 +64,7 @@ python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"
 python -c "import sklearn; print('sklearn %s' % sklearn.__version__)"
 python -c "import deap; print('deap %s' % deap.__version__)"
+python -c "import xgboost; print('xgboost %s ' % xgboost.__version__)"
 python -c "import update_checker; print('update_checker %s' % update_checker.__version__)"
 python -c "import tqdm; print('tqdm %s' % tqdm.__version__)"
 python setup.py build_ext --inplace

--- a/ci/.travis_test.sh
+++ b/ci/.travis_test.sh
@@ -14,6 +14,7 @@ python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"
 python -c "import sklearn; print('sklearn %s' % sklearn.__version__)"
 python -c "import deap; print('deap %s' % deap.__version__)"
+python -c "import xgboost; print('xgboost %s ' % xgboost.__version__)"
 python -c "import update_checker; print('update_checker %s ' % update_checker.__version__)"
 python -c "import tqdm; print('tqdm %s' % tqdm.__version__)"
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ This project is hosted at https://github.com/rhiever/tpot
 ''',
     zip_safe=True,
     install_requires=['numpy', 'scipy', 'scikit-learn', 'deap', 'update_checker', 'tqdm'],
+    extras_require={'xgboost': ['xgboost']},
     classifiers=[
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -567,8 +567,8 @@ class TPOTBase(BaseEstimator):
         except Exception:
             # Catch-all: Do not allow one pipeline that crashes to cause TPOT
             # to crash. Instead, assign the crashing pipeline a poor fitness
-            import traceback
-            traceback.print_exc()
+            # import traceback
+            # traceback.print_exc()
             return 5000., -5000.
         finally:
             if not self._pbar.disable:

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -567,8 +567,8 @@ class TPOTBase(BaseEstimator):
         except Exception:
             # Catch-all: Do not allow one pipeline that crashes to cause TPOT
             # to crash. Instead, assign the crashing pipeline a poor fitness
-            # import traceback
-            # traceback.print_exc()
+            import traceback
+            traceback.print_exc()
             return 5000., -5000.
         finally:
             if not self._pbar.disable:

--- a/tpot/operators/classifiers/__init__.py
+++ b/tpot/operators/classifiers/__init__.py
@@ -31,3 +31,7 @@ from .passive_aggressive import *
 from .logistic_regression import *
 from .knnc import *
 from .gradient_boosting import *
+try:
+    from .xg_boost import *
+except ImportError:
+    pass

--- a/tpot/operators/classifiers/xg_boost.py
+++ b/tpot/operators/classifiers/xg_boost.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright 2016 Randal S. Olson
+
+This file is part of the TPOT library.
+
+The TPOT library is free software: you can redistribute it and/or
+modify it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your option)
+any later version.
+
+The TPOT library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+details. You should have received a copy of the GNU General Public License along
+with the TPOT library. If not, see http://www.gnu.org/licenses/.
+
+"""
+
+from .base import Classifier
+from xgboost import XGBClassifier
+
+
+class TPOTXGBClassifier(Classifier):
+    """Fits an XGBoost Classifier
+
+    Parameters
+    ----------
+    learning_rate: float
+        Shrinks the contribution of each tree by learning_rate
+    subsample: float
+        Maximum number of features to use (proportion of total features)
+
+    """
+    import_hash = {'xgboost': ['XGBClassifier']}
+    sklearn_class = XGBClassifier
+    arg_types = (float, float)
+
+    def __init__(self):
+        pass
+
+    def preprocess_args(self, learning_rate, subsample):
+        learning_rate = min(1., max(learning_rate, 0.0001))
+        subsample = min(1., max(subsample, 0.1))
+
+        return {
+            'learning_rate': learning_rate,
+            'subsample': subsample,
+            'n_estimators': 500
+        }


### PR DESCRIPTION
## What does this PR do?

Adds XGBoost as an optional dependency

## Where should the reviewer start?

* `tpot/operators/classifers/xg_boost.py`
* `tpot/operators/classifiers/__init__.py`

## How should this PR be tested?

Running TPOT on a machine with xgboost installed and a machine without xgboost installed.

## What are the relevant issues?

#154 

- Do the docs need to be updated?

Yes

- Does this PR add new (Python) dependencies?

Yes