### PR TITLE
adding warm_start functionality by storing  pop and self._hof if desired

### DIFF
--- a/docs/sources/using.md
+++ b/docs/sources/using.md
@@ -205,6 +205,12 @@ Note that you can pass several parameters to the TPOT instantiation call:
 <td>[True, False]</td>
 <td>Flag indicating whether the TPOT version checker should be disabled.</td>
 </tr>
+<tr>
+<td>warm_start</td>
+<td>[True, False]</td>
+<td>Flag indicating whether TPOT will reuse models from previous calls
+to fit() for faster operation</td>
+</tr>
 </table>
 
 Some example code with custom TPOT parameters might look like:

--- a/tests.py
+++ b/tests.py
@@ -46,7 +46,7 @@ def test_init_custom_parameters():
                     mutation_rate=0.05, crossover_rate=0.9,
                     scoring='accuracy', num_cv_folds=10,
                     verbosity=1, random_state=42,
-                    disable_update_check=True)
+                    disable_update_check=True, warm_start=True)
 
     assert tpot_obj.population_size == 500
     assert tpot_obj.generations == 1000
@@ -55,6 +55,7 @@ def test_init_custom_parameters():
     assert tpot_obj.scoring_function == 'accuracy'
     assert tpot_obj.num_cv_folds == 10
     assert tpot_obj.max_time_mins is None
+    assert tpot_obj.warm_start is True
     assert tpot_obj.verbosity == 1
     assert tpot_obj._optimized_pipeline is None
     assert tpot_obj._fitted_pipeline is None
@@ -193,6 +194,24 @@ def test_predict_2():
     result = tpot_obj.predict(testing_features)
 
     assert result.shape == (testing_features.shape[0],)
+
+
+def test_warm_start():
+    """Assert that the TPOT warm_start flag stores the pop and pareto_front from the first run"""
+    tpot_obj = TPOTClassifier(random_state=42, population_size=1, generations=1, verbosity=0, warm_start=True)
+    tpot_obj.fit(training_features, training_classes)
+
+    assert tpot_obj._pop != None
+    assert tpot_obj._pareto_front != None
+
+    first_pop = tpot_obj._pop
+    first_pareto_front = tpot_obj._pareto_front
+
+    tpot_obj.random_state = 21
+    tpot_obj.fit(training_features, training_classes)
+
+    assert tpot_obj._pop == first_pop
+    assert tpot_obj._pareto_front == first_pareto_front
 
 
 def test_fit():

--- a/tpot/decorators.py
+++ b/tpot/decorators.py
@@ -44,13 +44,13 @@ def _gp_new_generation(func):
         if not self._pbar.disable:
             # Print only the best individual fitness
             if self.verbosity == 2:
-                high_score = abs(max([self._hof.keys[x].wvalues[1] for x in range(len(self._hof.keys))]))
+                high_score = abs(max([self._pareto_front.keys[x].wvalues[1] for x in range(len(self._pareto_front.keys))]))
                 self._pbar.write('Generation {0} - Current best internal CV score: {1}'.format(self._gp_generation, high_score))
 
             # Print the entire Pareto front
             elif self.verbosity == 3:
                 self._pbar.write('Generation {} - Current Pareto front scores:'.format(self._gp_generation))
-                for pipeline, pipeline_scores in zip(self._hof.items, reversed(self._hof.keys)):
+                for pipeline, pipeline_scores in zip(self._pareto_front.items, reversed(self._pareto_front.keys)):
                     self._pbar.write('{}\t{}\t{}'.format(int(abs(pipeline_scores.wvalues[0])),
                                                          abs(pipeline_scores.wvalues[1]),
                                                          pipeline))

--- a/tpot/driver.py
+++ b/tpot/driver.py
@@ -202,15 +202,15 @@ def main():
     tpot.fit(training_features, training_classes)
 
     if args.VERBOSITY in [1, 2] and tpot._optimized_pipeline:
-        training_score = max([tpot._hof.keys[x].wvalues[1] for x in range(len(tpot._hof.keys))])
+        training_score = max([tpot._pareto_front.keys[x].wvalues[1] for x in range(len(tpot._pareto_front.keys))])
         print('\nTraining score: {}'.format(abs(training_score)))
         print('Holdout score: {}'.format(tpot.score(testing_features, testing_classes)))
 
-    elif args.VERBOSITY >= 3 and tpot._hof:
+    elif args.VERBOSITY >= 3 and tpot._pareto_front:
         print('Final Pareto front testing scores:')
 
-        for pipeline, pipeline_scores in zip(tpot._hof.items, reversed(tpot._hof.keys)):
-            tpot._fitted_pipeline = tpot._hof_fitted_pipelines[str(pipeline)]
+        for pipeline, pipeline_scores in zip(tpot._pareto_front.items, reversed(tpot._pareto_front.keys)):
+            tpot._fitted_pipeline = tpot._pareto_front_fitted_pipelines[str(pipeline)]
             print('{}\t{}\t{}'.format(int(abs(pipeline_scores.wvalues[0])),
                                       tpot.score(testing_features, testing_classes),
                                       pipeline))


### PR DESCRIPTION
## What does this PR do?

Hi!  So I made a crack at this after v0.6 appeared to push up, here's what I've got so far:

I'm storing/not-rewriting pop and _hof in the case of a warm_start; I -think- that was the general plan.
## Where should the reviewer start?

I've only made additions to tpot/base.py .  The existing nosetests all seem to run fine, but I feel like I should add some others–I'm not 100% sure what to test in terms of the tpot lifecycle and when the stored variables should exist, so I'd appreciate some guidance on that.  Would it be easier to do in the form of a Pull Request?

Also, I looked at driver.py (is this feature also meant to be accessible from the command line?) and thought I'd add something like this:

``` python
    parser.add_argument('--warm-start', action='store', dest='WARM_START', default=False,
        choices=[True, False], type=bool, help='use previously generated models')
```

But I'm not entirely sure if that makes any sense (can the command line pass boolean arguments?  Wouldn't the api be better being something like `-ws` which if added will flag `warm_start` to `True`?) so yeah, some guidance there would also be appreciated as well.  I'm not 100% clear on how tpot is called from the command line either...  does it boot up a new python process whenever you do so?  In which case, is warm_start even possible in that context?

So!  That's where I'm at, hopefully I didn't miss the boat completely!

Let me know what you think at your convenience!
## How should this PR be tested?

Could use some guidance on that!
## What are the relevant issues?
#246
## Questions:
- Do the docs need to be updated?
  Yes, if the warm_start functionality is exposed to the end user.
- Does this PR add new (Python) dependencies?
  Nope.
