### PR TITLE
Add two synthetic features: class predictions and class probabilities into classifcation operators

### DIFF
--- a/tpot/export_utils.py
+++ b/tpot/export_utils.py
@@ -196,7 +196,6 @@ def generate_pipeline_code(pipeline_tree):
 def process_operator(operator, depth=0):
     steps = []
     op_name = operator[0]
-
     if op_name == "CombineDFs":
         steps.append(
             _combine_dfs(operator[1], operator[2])
@@ -204,15 +203,13 @@ def process_operator(operator, depth=0):
     else:
         input_name, args = operator[1], operator[2:]
         tpot_op = operators.Operator.get_by_name(op_name)
-
         if input_name != 'input_matrix':
             steps.extend(process_operator(input_name, depth + 1))
-
         # If the step is an estimator and is not the last step then we must
         # add its class probabilities and class prodictions as synthetic features and only for classifier
         if tpot_op.root  and depth > 0:
-            # only for classifier unless will casue error when using regressor
-            if tpot_op.classification:
+            #  for classifier with predict_proba
+            if tpot_op.classification and hasattr(tpot_op.sklearn_class, 'predict_proba'):
                 step = ("make_union("
                 " make_pipeline("
                 " VotingClassifier([(\"est_prob\", {OP_CODE})], voting=\"soft\"),"

--- a/tpot/export_utils.py
+++ b/tpot/export_utils.py
@@ -213,10 +213,13 @@ def process_operator(operator, depth=0):
         if tpot_op.root  and depth > 0:
             # only for classifier unless will casue error when using regressor
             if tpot_op.classification:
-                step = "make_union(make_pipeline(VotingClassifier([(\"est_prob\", {})], voting = \"soft\"), ".format(tpot_op.export(*args))
-                step += "FunctionTransformer(lambda X: X[0], validate=False)), "
-                step += "VotingClassifier([(\"est_class\", {})], voting = \"hard\")".format(tpot_op.export(*args))
-                step += ", FunctionTransformer(lambda X: X))"
+                step = ("make_union("
+                " make_pipeline("
+                " VotingClassifier([(\"est_prob\", {OP_CODE})], voting=\"soft\"),"
+                " FunctionTransformer(lambda X: X[0], validate=False)),"
+                " VotingClassifier([(\"est_class\", {OP_CODE})], voting=\"hard\"),"
+                " FunctionTransformer(lambda X: X)"
+                ")").format(OP_CODE=tpot_op.export(*args))
             else:
                 step = "make_union(VotingClassifier([(\"est\", {})]), FunctionTransformer(lambda X: X))".format(tpot_op.export(*args))
             steps.append(step)


### PR DESCRIPTION
[please review the [contribution guidelines](http://rhiever.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]
## What does this PR do?

Add two synthetic features: class predictions and class probabilities into classifcation operators
## Where should the reviewer start?

Line 214 in export_utils.py
## How should this PR be tested?

 MNIST example
## Any background context you want to provide?
## What are the relevant issues?
#214
## Questions:

@teaearlgraycold : The old synthetic feature (only adding class predictions) can work for both classifier and regressor. I kept it for regressor. But I am not sure whether it is reasonable put regressor into VotingClassifier. Will it output predicted (expected) values to next regressor in a pipeline? 
