### PR TITLE
Fix bugs in timeout in Linux and MacOS

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -42,14 +42,14 @@ from update_checker import update_check
 
 from ._version import __version__
 from .export_utils import export_pipeline, expr_to_tree, generate_pipeline_code
-from .decorators import _gp_new_generation#, _timeout
+from .decorators import _gp_new_generation, _timeout
 from . import operators
 from .operators import CombineDFs
 from .gp_types import Bool, Output_DF
 from .metrics import SCORERS
 
 # add time limit for imported function
-#cross_val_score = _timeout(cross_val_score)
+cross_val_score = _timeout(cross_val_score)
 
 class TPOTBase(BaseEstimator):
     """TPOT automatically creates and optimizes machine learning pipelines using genetic programming"""
@@ -559,7 +559,7 @@ class TPOTBase(BaseEstimator):
 
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore')
-                cv_scores = cross_val_score(sklearn_pipeline, features, classes,
+                cv_scores = cross_val_score(self, sklearn_pipeline, features, classes,
                     cv=self.num_cv_folds, scoring=self.scoring_function)
 
             resulting_score = np.mean(cv_scores)

--- a/tpot/decorators.py
+++ b/tpot/decorators.py
@@ -95,40 +95,55 @@ def _timeout(func):
         second = int(time_minute * 60)
         # time limit should be at least 1 second
         return max(second, 1)
-
+    class TIMEOUT(RuntimeError):
+            """
+            Inhertis from RuntimeError
+            """
+            pass
+    
+    def timeout_signal_handler(signum, frame):
+        """
+        signal handler for _timeout function
+        rasie TIMEOUT exception
+        """
+        raise TIMEOUT("Time Out!")
     if not sys.platform.startswith('win'):
-        from multiprocessing import Pool, TimeoutError, freeze_support
-
-        @wraps(func) 
-        def limitedTime(self, *args, **kw):
-            # turn off trackback
-            sys.tracebacklimit = 0
-            # converte time to seconds
-            max_time_seconds = convert_mins_to_secs(self.max_eval_time_mins)
-            pool = Pool(1) # open a pool with only one process
-            subproc = pool.apply_async(func, args, kw) # submit process
+        from signal import SIGXCPU, signal, getsignal
+        from resource import getrlimit, setrlimit, RLIMIT_CPU, getrusage, RUSAGE_SELF
+        # timeout uses the CPU time 
+        @wraps(func)
+        def limitedTime(self,*args, **kw):
+            # don't show traceback 
+            sys.tracebacklimit=0
+            # save old signal
+            old_signal_hander = getsignal(SIGXCPU)
+            # change signal
+            signal(SIGXCPU, timeout_signal_handler)
+            max_time_second = convert_mins_to_secs(self.max_eval_time_mins)
+            r = getrusage(RUSAGE_SELF)
+            cpu_time = r.ru_utime + r.ru_stime
+            current = getrlimit(RLIMIT_CPU)
             try:
-                # return output with time limit
-                return subproc.get(max_time_seconds)
-            except TimeoutError:
+                setrlimit(RLIMIT_CPU, (cpu_time+max_time_second, current[1]))
+                ret = func(*args, **kw)
+            except RuntimeError:
                 if self.verbosity > 1:
                     self._pbar.write('Timeout during evaluation of pipeline #{0}. Skipping to the next pipeline.'.format(self._pbar.n + 1))
-                # return None
-                return None
+                ret = None
             finally:
-                # terminate the pool
-                pool.terminate()
-                pool.join()
-                # reset trackback info
-                sys.tracebacklimit = 1000
+                # reset cpu time limit and trackback
+                setrlimit(RLIMIT_CPU, current)
+                sys.tracebacklimit=1000
+                # reset signal
+                signal(SIGXCPU, old_signal_hander)
+            return ret
     else:
         from threading import Timer
         from _thread import interrupt_main
-
         @wraps(func)
         def limitedTime(self, *args, **kw):
             if self.verbosity > 1 and self._pbar.n == 0:
-                self._pbar.write('Warning: No KeyBoardInterrupt for evaluating pipelines.')
+                self._pbar.write('Warning: No KeyBoardInterrupt for evaluating pipelines!')
             sys.tracebacklimit = 0
             max_time_seconds = convert_mins_to_secs(self.max_eval_time_mins)
             timer = Timer(max_time_seconds, interrupt_main)
@@ -142,6 +157,6 @@ def _timeout(func):
             finally:
                 timer.cancel()
                 sys.tracebacklimit = 1000
-                return ret
+            return ret
     # return func
     return limitedTime


### PR DESCRIPTION
[please review the [contribution guidelines](http://rhiever.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]

## What does this PR do?

Fix a bug in the old time_out function


## Where should the reviewer start?

decorators.py

## How should this PR be tested?

from tpot import TPOTClassifier
from sklearn.datasets import load_digits
from sklearn.cross_validation import train_test_split

digits = load_digits()
X_train, X_test, y_train, y_test = train_test_split(digits.data, digits.target,
                                                            train_size=0.75, test_size=0.25)

tpot = TPOTClassifier(generations=3, population_size=40, verbosity=2,max_eval_time_mins=0.02,random_state=99)
tpot.fit(X_train, y_train)


## Questions:

Timeout will work in but still not support KeyBoardInterrupt in Windows. Any suggestion?