### PR TITLE
Hot patch for solving the keyboardinterrupt in Windows & New timeout function for Windows OS

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -48,6 +48,19 @@ from .operators import CombineDFs
 from .gp_types import Bool, Output_DF
 from .metrics import SCORERS
 
+# hot patch for Windows: solve the problem of crashing python after Ctrl + C in Windows OS
+if sys.platform.startswith('win'):
+    import win32api
+    try:
+        import _thread
+    except ImportError:
+        import thread as _thread
+    def handler(dwCtrlType, hook_sigint=_thread.interrupt_main):
+        if dwCtrlType == 0: # CTRL_C_EVENT
+            hook_sigint()
+            return 1 # don't chain to the next handler
+        return 0
+    win32api.SetConsoleCtrlHandler(handler, 1)
 # add time limit for imported function
 cross_val_score = _timeout(cross_val_score)
 
@@ -321,6 +334,7 @@ class TPOTBase(BaseEstimator):
         # Allow for certain exceptions to signal a premature fit() cancellation
         except (KeyboardInterrupt, SystemExit):
             if self.verbosity > 0:
+                print('') # just for better interface
                 print('GP closed prematurely - will use current best pipeline')
         finally:
             # Close the progress bar
@@ -561,8 +575,10 @@ class TPOTBase(BaseEstimator):
                 warnings.simplefilter('ignore')
                 cv_scores = cross_val_score(self, sklearn_pipeline, features, classes,
                     cv=self.num_cv_folds, scoring=self.scoring_function)
-
-            resulting_score = np.mean(cv_scores)
+            try:
+                resulting_score = np.mean(cv_scores)
+            except TypeError:
+                raise TypeError('Warning: cv_scores is None due to timeout during evaluation of pipeline')
 
         except Exception:
             # Catch-all: Do not allow one pipeline that crashes to cause TPOT

--- a/tpot/decorators.py
+++ b/tpot/decorators.py
@@ -146,7 +146,8 @@ def _timeout(func):
                 self.kwargs = kwargs
                 self.result = None
                 self.daemon = True
-
+            def stop(self):
+                self._stop.set()
             def run(self):
                 try:
                     # Note: changed name of the thread to "MainThread" to avoid such warning from joblib (maybe bugs)
@@ -154,7 +155,7 @@ def _timeout(func):
                     current_thread().name = 'MainThread'
                     self.result = func(*self.args, **self.kwargs)
                 except Exception:
-                    raise Exception
+                    pass
         @wraps(func)
         def limitedTime(self, *args, **kw):
             sys.tracebacklimit = 0
@@ -167,6 +168,8 @@ def _timeout(func):
             if tmp_it.isAlive():
                 if self.verbosity > 1:
                     self._pbar.write('Timeout during evaluation of pipeline #{0}. Skipping to the next pipeline.'.format(self._pbar.n + 1))
+            sys.tracebacklimit=1000
             return tmp_it.result
+            tmp_it.stop()
     # return func
     return limitedTime

--- a/tpot/decorators.py
+++ b/tpot/decorators.py
@@ -147,7 +147,7 @@ def _timeout(func):
                 self.result = None
                 self.daemon = True
             def stop(self):
-                self._stop.set()
+                self._stop()
             def run(self):
                 try:
                     # Note: changed name of the thread to "MainThread" to avoid such warning from joblib (maybe bugs)

--- a/tpot/decorators.py
+++ b/tpot/decorators.py
@@ -107,7 +107,7 @@ def _timeout(func):
         rasie TIMEOUT exception
         """
         raise TIMEOUT("Time Out!")
-    if sys.platform.startswith('win'):#not sys.platform.startswith('win'):
+    if not sys.platform.startswith('win'):
         from signal import SIGXCPU, signal, getsignal
         from resource import getrlimit, setrlimit, RLIMIT_CPU, getrusage, RUSAGE_SELF
         # timeout uses the CPU time 


### PR DESCRIPTION
[please review the [contribution guidelines](http://rhiever.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]

## What does this PR do?

Fix the bugs about Ctrl-C crashing Python in Windows OS 
This bugs are related to [scipy.stats installs FORTRAN Control-C handler](https://github.com/ContinuumIO/anaconda-issues/issues/905)

Add new timeout function for windows. This function still use wall time instead of CPU time ( timeout function for Linux and MacOS is CPU time). But now it allow users to use Ctrl+C to interrupt pipeline evaluation and save the best pipeline.



## Where should the reviewer start?

Line 51 in base.py

Line141 in decorators.py


## How should this PR be tested?

from tpot import TPOTClassifier
from sklearn.datasets import load_digits
from sklearn.cross_validation import train_test_split

digits = load_digits()
X_train, X_test, y_train, y_test = train_test_split(digits.data, digits.target,
                                                    train_size=0.75, test_size=0.25)
tpot = TPOTClassifier(generations=5, population_size=40,max_eval_time_mins=0.02,verbosity=2, random_state=99)
tpot.fit(X_train, y_train)
                  

## Any background context you want to provide?

A thick for dealing with joblib warning under threads is from this issue [Multiprocessing backed parallel loops cannot be nested below threads, setting n_jobs=1 ](https://github.com/joblib/joblib/issues/180)

## What are the relevant issues?

#286 

