### PR TITLE
Remove 'cosine' affinity type from FeatureAgglomeration to avoid memory overflow

### DIFF
--- a/tpot/operators/preprocessors/feat_agg.py
+++ b/tpot/operators/preprocessors/feat_agg.py
@@ -49,7 +49,7 @@ class TPOTFeatureAgglomeration(Preprocessor):
         linkage_types = ['ward', 'complete', 'average']
         linkage_name = linkage_types[linkage % len(linkage_types)]
 
-        affinity_types = ['euclidean', 'l1', 'l2', 'manhattan', 'cosine', 'precomputed']
+        affinity_types = ['euclidean', 'l1', 'l2', 'manhattan', 'precomputed']
         affinity_name = 'euclidean' if linkage_name == 'ward' else affinity_types[affinity % len(affinity_types)]
 
         return {


### PR DESCRIPTION
## What does this PR do?

Avoid memory overflow due to possible bugs about "cosine" affinity type in FeatureAgglomeration. No issue with other affinity types.
## Where should the reviewer start?

Use the codes below to reproduce the memory overflow with the dataset in issue #271 

```

from sklearn.cluster import FeatureAgglomeration

import numpy as np
import time
train_data = np.genfromtxt('fold_2_trainFeatVec.csv', delimiter=',')
train_labels= np.genfromtxt('fold_2_trainLabels.csv', delimiter=',')


fa = FeatureAgglomeration(affinity="cosine", linkage="average") # no matter linage ="average" or "complete"
time_start= time.time()
fa.fit(train_data, train_labels) # memory keeping increasing here
time_end = time.time()
print('Time usage:',time_end-time_start)

```
## What are the relevant issues?
#271
#252
