### PR TITLE
Add sag solver for logistic regression

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -561,7 +561,7 @@ class TPOTBase(BaseEstimator):
 
             # Count the number of pipeline operators as a measure of pipeline complexity
             operator_count = 0
-            
+
             # add time limit for evaluation of pipeline
             for i in range(len(individual)):
                 node = individual[i]

--- a/tpot/operators/classifiers/logistic_regression.py
+++ b/tpot/operators/classifiers/logistic_regression.py
@@ -32,28 +32,34 @@ class TPOTLogisticRegression(Classifier):
         Inverse of regularization strength; must be a positive value. Like in support vector machines, smaller values specify stronger regularization.
     penalty: int
         Integer used to specify the norm used in the penalization (l1 or l2)
-    dual: bool
+    dual: bool = False in each case
         Select the algorithm to either solve the dual or primal optimization problem.
-
+    solver: sag (Note: sciket-learn version > 0.17) for l1 and liblinear for l2
+        Algorithm to use in the optimization problem.
+        Stochastic Average Gradient descent solver.
+        Note that ‘sag’ fast convergence is only guaranteed on features with approximately the same scale.
+        ‘newton-cg’, ‘lbfgs’ and ‘sag’ only handle L2 penalty.
     """
     import_hash = {'sklearn.linear_model': ['LogisticRegression']}
     sklearn_class = LogisticRegression
-    arg_types = (float, int, Bool)
+    arg_types = (float, int)
 
     def __init__(self):
         pass
 
-    def preprocess_args(self, C, penalty, dual):
+    def preprocess_args(self, C, penalty):
         C = min(50., max(0.0001, C))
 
         penalty_values = ['l1', 'l2']
         penalty_selection = penalty_values[penalty % len(penalty_values)]
-
+        dual = False
         if penalty_selection == 'l1':
-            dual = False
-
+            solver = 'liblinear'
+        else:
+            solver = 'sag'
         return {
             'C': C,
             'penalty': penalty_selection,
-            'dual': dual
+            'dual': dual,
+            'solver': solver
         }


### PR DESCRIPTION
## What does this PR do?

Add sag solver for logistic regression to handle large dataset.
## Where should the reviewer start?

tpot/operators/classifiers/logistic_regression.py
## How should this PR be tested?

Any TPOT examples
## What are the relevant issues?
#271
#292
#252
## Questions:

‘sag’ only handle L2 penalty and only works with dual = False. It means dual is False in both l1 and l2 penalty. Thus, no dual argument if sag is added. Is it OK?
