### PR TITLE
Customize operator list using exclude_operators (-exop) and include_operators (-inop) arguments

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -77,6 +77,19 @@ def test_init_max_time_mins():
     assert tpot_obj.generations == 1000000
     assert tpot_obj.max_time_mins == 30
 
+def test_init_exclude_operators():
+    """Assert that the TPOT init stores the list of excluded operators"""
+
+    tpot_obj = TPOTClassifier(exclude_operators='LogisticRegression,GradientBoostingRegressor')
+
+    assert tpot_obj.exclude_operators == ['LogisticRegression','GradientBoostingRegressor']
+
+def test_init_include_operators():
+    """Assert that the TPOT init stores the list of excluded operators"""
+
+    tpot_obj = TPOTClassifier(include_operators='LogisticRegression,GradientBoostingRegressor')
+
+    assert tpot_obj.include_operators == ['LogisticRegression','GradientBoostingRegressor']
 
 def test_get_params():
     """Assert that get_params returns the exact dictionary of parameters used by TPOT"""

--- a/tests.py
+++ b/tests.py
@@ -78,18 +78,29 @@ def test_init_max_time_mins():
     assert tpot_obj.max_time_mins == 30
 
 def test_init_exclude_operators():
-    """Assert that the TPOT init stores the list of excluded operators"""
+    """Assert that the TPOT stores and use the list of excluded operators"""
 
-    tpot_obj = TPOTClassifier(exclude_operators='LogisticRegression,GradientBoostingRegressor')
+    tpot_obj = TPOTClassifier(exclude_operators='LogisticRegression,GradientBoostingClassifier')
+    exop_num = 0
+    for op in tpot_obj.exclude_operators:
+        if list(tpot_obj.operators_context.keys()).count(op):
+            exop_num += 1
 
-    assert tpot_obj.exclude_operators == ['LogisticRegression','GradientBoostingRegressor']
+    assert tpot_obj.exclude_operators == ['LogisticRegression','GradientBoostingClassifier']
+    assert exop_num == 0
 
 def test_init_include_operators():
-    """Assert that the TPOT init stores the list of excluded operators"""
+    """Assert that the TPOT stores and use the list of included operators"""
 
-    tpot_obj = TPOTClassifier(include_operators='LogisticRegression,GradientBoostingRegressor')
+    tpot_obj = TPOTClassifier(include_operators='LogisticRegression,GradientBoostingClassifier')
 
-    assert tpot_obj.include_operators == ['LogisticRegression','GradientBoostingRegressor']
+    inop_num = 0
+    for op in tpot_obj.include_operators:
+        if list(tpot_obj.operators_context.keys()).count(op):
+            inop_num += 1
+
+    assert tpot_obj.include_operators == ['LogisticRegression','GradientBoostingClassifier']
+    assert inop_num == 2
 
 def test_get_params():
     """Assert that get_params returns the exact dictionary of parameters used by TPOT"""

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -210,6 +210,7 @@ class TPOTBase(BaseEstimator):
             exclude_op = []
         if self.include_operators:
             self.include_operators = self.include_operators.split(',')
+            include_op = []
         # Add all operators to the primitive set
         for op in operators.Operator.inheritors():
 
@@ -222,8 +223,15 @@ class TPOTBase(BaseEstimator):
                 if self.exclude_operators.count(op.__name__):
                     exclude_op.append(op.__name__)
                     # A reminder about which operator has remoted from TPOT pipeline optimization process
-                    print('Note: {} operator has removed from TPOT pipeline optimization process'.format(op.__name__))
+                    print('Note: {} operator is excluded from TPOT pipeline optimization process of {}'.format(op.__name__, self.__class__.__name__))
                     continue
+
+            if self.include_operators:
+                if not self.include_operators.count(op.__name__):
+                    continue
+                else:
+                    print('Note: {} operator is included in TPOT pipeline optimization process of {}'.format(op.__name__, self.__class__.__name__))
+                    include_op.append(op.__name__)
 
             if op.root:
                 # We need to add rooted primitives twice so that they can
@@ -249,13 +257,20 @@ class TPOTBase(BaseEstimator):
 
         self._pset.addPrimitive(CombineDFs(), [np.ndarray, np.ndarray], np.ndarray)
 
-        # test if all operators have been excluded
+        # test if all operators have been excluded/included
         if self.exclude_operators:
             if len(self.exclude_operators) != len(exclude_op):
                 for tmpop in self.exclude_operators:
                     if not exclude_op.count(tmpop):
                         # A friendly reminder about the operator in customied excluding list is not in TPOTRegressor/TPOTClassifier
-                        print('Note: {} operator has not been designed to be applied in {}'.format(tmpop,self.__class__.__name__))
+                        print('Warning: {} operator has not been designed to be applied in {}'.format(tmpop,self.__class__.__name__))
+
+        if self.include_operators:
+            if len(self.include_operators) != len(include_op):
+                for tmpop in self.include_operators:
+                    if not include_op.count(tmpop):
+                        # A friendly reminder about the operator in customied excluding list is not in TPOTRegressor/TPOTClassifier
+                        print('Warning: {} operator has not been designed to be applied in {}'.format(tmpop,self.__class__.__name__))
 
 
         # Terminals

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -222,7 +222,7 @@ class TPOTBase(BaseEstimator):
             if self.exclude_operators:
                 if self.exclude_operators.count(op.__name__):
                     exclude_op.append(op.__name__)
-                    # A reminder about which operator has remoted from TPOT pipeline optimization process
+                    # A reminder about which operator is excluded from TPOT pipeline optimization process
                     print('Note: {} operator is excluded from TPOT pipeline optimization process of {}'.format(op.__name__, self.__class__.__name__))
                     continue
 
@@ -230,6 +230,7 @@ class TPOTBase(BaseEstimator):
                 if not self.include_operators.count(op.__name__):
                     continue
                 else:
+                    # A reminder about which operator is included in TPOT pipeline optimization process
                     print('Note: {} operator is included in TPOT pipeline optimization process of {}'.format(op.__name__, self.__class__.__name__))
                     include_op.append(op.__name__)
 
@@ -246,7 +247,6 @@ class TPOTBase(BaseEstimator):
             # may be evaluated directly
             for key in sorted(op.import_hash.keys()):
                 module_list = ', '.join(sorted(op.import_hash[key]))
-
                 if key.startswith('tpot.'):
                     exec('from {} import {}'.format(key[4:], module_list))
                 else:
@@ -269,7 +269,7 @@ class TPOTBase(BaseEstimator):
             if len(self.include_operators) != len(include_op):
                 for tmpop in self.include_operators:
                     if not include_op.count(tmpop):
-                        # A friendly reminder about the operator in customied excluding list is not in TPOTRegressor/TPOTClassifier
+                        # A friendly reminder about the operator in customied including list is not in TPOTRegressor/TPOTClassifier
                         print('Warning: {} operator has not been designed to be applied in {}'.format(tmpop,self.__class__.__name__))
 
 

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -70,6 +70,7 @@ class TPOTBase(BaseEstimator):
     def __init__(self, population_size=100, generations=100,
                  mutation_rate=0.9, crossover_rate=0.05,
                  scoring=None, num_cv_folds=3, max_time_mins=None, max_eval_time_mins=5,
+                 exclude_operators = None, include_operators = None,
                  random_state=None, verbosity=0,
                  disable_update_check=False):
         """Sets up the genetic programming algorithm for pipeline optimization.
@@ -119,6 +120,10 @@ class TPOTBase(BaseEstimator):
             How many minutes TPOT has to optimize a single pipeline.
             Setting this parameter to higher values will allow TPOT to explore more complex
             pipelines but will also allow TPOT to run longer.
+        exclude_operators: *str (default None, e.g. ExtraTreesClassifier,GradientBoostingClassifier)
+            Operator(s) need to excluded from TPOT pipeline optimization process
+        include_operators: *str (default None)
+            Only operators need to included in TPOT pipeline optimization process
         random_state: int (default: 0)
             The random number generator seed for TPOT. Use this to make sure
             that TPOT will give you the same results each time you run it
@@ -150,6 +155,8 @@ class TPOTBase(BaseEstimator):
         self.generations = generations
         self.max_time_mins = max_time_mins
         self.max_eval_time_mins = max_eval_time_mins
+        self.exclude_operators = exclude_operators
+        self.include_operators = include_operators
 
         # Schedule TPOT to run for a very long time if the user specifies a run-time
         # limit TPOT will automatically interrupt itself when the timer runs out
@@ -197,10 +204,26 @@ class TPOTBase(BaseEstimator):
         # Rename pipeline input to "input_df"
         self._pset.renameArguments(ARG0='input_matrix')
 
+        if self.exclude_operators:
+            self.exclude_operators = self.exclude_operators.split(',')
+            # recode the operators of remoted operators
+            exclude_op = []
+        if self.include_operators:
+            self.include_operators = self.include_operators.split(',')
         # Add all operators to the primitive set
         for op in operators.Operator.inheritors():
+
+            # _ignore_operator only separate classification and regression
             if self._ignore_operator(op):
                 continue
+            # customize operator settings
+
+            if self.exclude_operators:
+                if self.exclude_operators.count(op.__name__):
+                    exclude_op.append(op.__name__)
+                    # A reminder about which operator has remoted from TPOT pipeline optimization process
+                    print('Note: {} operator has removed from TPOT pipeline optimization process'.format(op.__name__))
+                    continue
 
             if op.root:
                 # We need to add rooted primitives twice so that they can
@@ -225,6 +248,15 @@ class TPOTBase(BaseEstimator):
                     self.operators_context[var] = eval(var)
 
         self._pset.addPrimitive(CombineDFs(), [np.ndarray, np.ndarray], np.ndarray)
+
+        # test if all operators have been excluded
+        if self.exclude_operators:
+            if len(self.exclude_operators) != len(exclude_op):
+                for tmpop in self.exclude_operators:
+                    if not exclude_op.count(tmpop):
+                        # A friendly reminder about the operator in customied excluding list is not in TPOTRegressor/TPOTClassifier
+                        print('Note: {} operator has not been designed to be applied in {}'.format(tmpop,self.__class__.__name__))
+
 
         # Terminals
         int_terminals = np.concatenate((
@@ -561,7 +593,7 @@ class TPOTBase(BaseEstimator):
 
             # Count the number of pipeline operators as a measure of pipeline complexity
             operator_count = 0
-            
+
             # add time limit for evaluation of pipeline
             for i in range(len(individual)):
                 node = individual[i]

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -207,10 +207,10 @@ class TPOTBase(BaseEstimator):
         if self.exclude_operators:
             self.exclude_operators = self.exclude_operators.split(',')
             # recode the operators of remoted operators
-            exclude_op = []
         if self.include_operators:
             self.include_operators = self.include_operators.split(',')
-            include_op = []
+        include_op = []
+        exclude_op = []
         # Add all operators to the primitive set
         for op in operators.Operator.inheritors():
 
@@ -258,19 +258,15 @@ class TPOTBase(BaseEstimator):
         self._pset.addPrimitive(CombineDFs(), [np.ndarray, np.ndarray], np.ndarray)
 
         # test if all operators have been excluded/included
-        if self.exclude_operators:
-            if len(self.exclude_operators) != len(exclude_op):
-                for tmpop in self.exclude_operators:
-                    if not exclude_op.count(tmpop):
-                        # A friendly reminder about the operator in customied excluding list is not in TPOTRegressor/TPOTClassifier
-                        print('Warning: {} operator has not been designed to be applied in {}'.format(tmpop,self.__class__.__name__))
-
-        if self.include_operators:
-            if len(self.include_operators) != len(include_op):
-                for tmpop in self.include_operators:
-                    if not include_op.count(tmpop):
-                        # A friendly reminder about the operator in customied including list is not in TPOTRegressor/TPOTClassifier
-                        print('Warning: {} operator has not been designed to be applied in {}'.format(tmpop,self.__class__.__name__))
+        op_init_list = [self.exclude_operators, self.include_operators]
+        op_work_list = [exclude_op, include_op]
+        for op_init,op_work in zip(op_init_list,op_work_list):
+            if op_init:
+                if len(op_init) != len(op_work):
+                    for tmpop in op_init:
+                        if not op_work.count(tmpop):
+                            # A friendly reminder about the operator in customied excluding list is not in TPOTRegressor/TPOTClassifier
+                            print('Warning: {} operator has not been designed to be applied in {}'.format(tmpop,self.__class__.__name__))
 
 
         # Terminals

--- a/tpot/driver.py
+++ b/tpot/driver.py
@@ -143,6 +143,16 @@ def main():
         'Setting this parameter to higher values will allow TPOT to explore more complex '
         'pipelines but will also allow TPOT to run longer.')
 
+    parser.add_argument('-exop', action='store', dest='EXCLUDED_OPERATOR', default=None,
+        type=str, help='Operator(s) is excluded from TPOT pipeline optimization process. '
+        'Use "," to separate multiple operators. '
+        'e.g. -exop LogisticRegression,GradientBoostingRegressor/ ')
+
+    parser.add_argument('-inop', action='store', dest='INCLUDED_OPERATOR', default=None,
+        type=str, help='operator(s) is included in TPOT pipeline optimization process. '
+        'Use "," to separate multiple operators. '
+        'e.g. -inop LogisticRegression,GradientBoostingRegressor ')
+
     parser.add_argument('-s', action='store', dest='RANDOM_STATE', default=None,
         type=int, help='Random number generator seed for reproducibility. Set '
         'this seed if you want your TPOT run to be reproducible with the same '
@@ -196,6 +206,7 @@ def main():
                 mutation_rate=args.MUTATION_RATE, crossover_rate=args.CROSSOVER_RATE,
                 num_cv_folds=args.NUM_CV_FOLDS, scoring=args.SCORING_FN,
                 max_time_mins=args.MAX_TIME_MINS, max_eval_time_mins=args.MAX_EVAL_MINS,
+                exclude_operators = args.EXCLUDED_OPERATOR, include_operators = args.INCLUDED_OPERATOR,
                 random_state=args.RANDOM_STATE, verbosity=args.VERBOSITY,
                 disable_update_check=args.DISABLE_UPDATE_CHECK)
 


### PR DESCRIPTION
## What does this PR do?

Customize operator list using exclude_operators (-exop) and include_operators (-inop) arguments.
## Where should the reviewer start?

TPOT init arguments
## How should this PR be tested?

Using any TPOT examples with two arguments like codes below:

```
from tpot import TPOTClassifier, TPOTRegressor

tpot1 = TPOTClassifier(generations=5, population_size=20,verbosity=2,
random_state=99,max_eval_time_mins= 0.05, 
exclude_operators = 'LogisticRegression,GradientBoostingRegressor,GradientBoostingClassifier')

tpot2 = TPOTRegressor(generations=5, population_size=20,verbosity=2,
random_state=99,max_eval_time_mins= 0.05, 
include_operators ='LinearSVR,GradientBoostingRegressor,GradientBoostingClassifier')

```
## What are the relevant issues?
#146
#296
