### PR TITLE
Adding TPOT into conda-forge

### DIFF
--- a/conda_recipes/tpot/meta.yaml
+++ b/conda_recipes/tpot/meta.yaml
@@ -57,8 +57,6 @@ about:
   license_family: Public-Domain
 
 
-#extra:
-  #recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
-    #- rhiever
+extra:
+  recipe-maintainers:
+    - rhiever

--- a/conda_recipes/tpot/meta.yaml
+++ b/conda_recipes/tpot/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "TPOT" %}
+{% set version = "0.6.7" %}
+{% set md5 = "69b7e0cc7733bf3c80f6b37a5474c295" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/a4/be/b7b5a3e0849efa1f7269d068b9ded6ab8d803f521efa7dce85cce11f96d9/{{ name }}-{{ version }}.tar.gz
+  md5: {{ md5 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  entry_points:
+    - tpot=tpot:main
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy
+    - scipy
+    - scikit-learn
+    - deap
+    - update_checker
+    - tqdm
+
+  run:
+    - python
+    - numpy
+    - scipy
+    - scikit-learn
+    - deap
+    - update_checker
+    - tqdm
+
+test:
+  imports:
+    - tpot
+    - tpot.operators
+    - tpot.operators.classifiers
+    - tpot.operators.preprocessors
+    - tpot.operators.regressors
+    - tpot.operators.selectors
+
+  commands:
+    - tpot --help
+
+
+about:
+  home: https://github.com/rhiever/tpot
+  license: GNU General Public License v3 (GPLv3)
+  summary: 'Tree-based Pipeline Optimization Tool'
+  license_family: Public-Domain
+
+
+#extra:
+  #recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    #- rhiever


### PR DESCRIPTION
## What does this PR do?

Add a conda recipe for adding TPOT into conda-forge. We need submit a PR at [staged-recipes](https://github.com/conda-forge/staged-recipes) with the recipe (comments is not allowed in the recipe, so I already deleted all the comments) to officially adding TPOT into conda-forge channel.

## Where should the reviewer start?

conda_recipes/tpot/meta.yaml

## How should this PR be tested?

```
# under the conda_recipes folder
conda config --add channels conda-forge
conda build tpot

```

## What are the relevant issues?
#165 


## Questions:

Because one dependency, deap, is only available in python 2.7, 3.4 and 3.5 in conda-forge, so the tpot can be only built in conda-forge with these 3 versions of pythons. For better compatibility, a update in recipe of this dependency is needed. Could we submitted another PR for updating deap in conda-forge?

