### PR TITLE
Hot patch of fixing a bug in time limit function in MacOS

### DIFF
--- a/tpot/decorators.py
+++ b/tpot/decorators.py
@@ -100,20 +100,20 @@ def _timeout(func):
             Inhertis from RuntimeError
             """
             pass
-    
+
     def timeout_signal_handler(signum, frame):
         """
         signal handler for _timeout function
         rasie TIMEOUT exception
         """
         raise TIMEOUT("Time Out!")
-    if not sys.platform.startswith('win'):
+    if sys.platform.startswith('linux'):
         from signal import SIGXCPU, signal, getsignal
         from resource import getrlimit, setrlimit, RLIMIT_CPU, getrusage, RUSAGE_SELF
-        # timeout uses the CPU time 
+        # timeout uses the CPU time
         @wraps(func)
         def limitedTime(self,*args, **kw):
-            # don't show traceback 
+            # don't show traceback
             sys.tracebacklimit=0
             # save old signal
             old_signal_hander = getsignal(SIGXCPU)


### PR DESCRIPTION
## What does this PR do?

resource.setrlimit sometimes doesn't respect when runing scikit-learn in macOS. It seems a old issue of python in macOS. So I limited the CPU time-limit function only works in Linux OS while wall time-limit funciton works in MacOS and Windows OS.

Additional link:
http://bugs.python.org/issue17409
http://stackoverflow.com/questions/15633474/python-on-macos-totally-ignoring-rlimit

## Where should the reviewer start?

line 110 in decorators.py


## How to detect the bug

Run these codes below in MacOS (verison 10.11.2 - 10.12.1).It should fail with "Cputime limit exceeded: 24" error message. It will fail randomly!!

But if you try the codes in Linux it will be all right.

```
from sklearn.model_selection import train_test_split, cross_val_score
from sklearn.linear_model import LogisticRegression
from sklearn.ensemble import ExtraTreesClassifier
from sklearn.datasets import make_classification
from sklearn.naive_bayes import BernoulliNB, GaussianNB, MultinomialNB
from resource import getrlimit, setrlimit, RLIMIT_CPU, getrusage, RUSAGE_SELF, RUSAGE_CHILDREN



X, y = make_classification(n_samples=200, n_features=800,
                                    n_informative=2, n_redundant=10,
                                    random_state=42)


classifor_list = {#"ExtraTreesClassifier": ExtraTreesClassifier, # pass
                    "LogisticRegression": LogisticRegression, # fail
                    #"MultinomialNB": MultinomialNB, # pass
                    #"GaussianNB": GaussianNB, # pass
                    "BernoulliNB": BernoulliNB # fail
                }



for key in classifor_list.keys():
    clf = classifor_list[key]()
    for i in range(300):
        if i == 0:
            print(key)
        print("test #",i+1,'for',key)
        r = getrusage(RUSAGE_SELF)
        cpu_time = r.ru_utime + r.ru_stime
        r_child = getrusage(RUSAGE_CHILDREN)
        child_time = r_child.ru_utime + r_child.ru_stime
        current = getrlimit(RLIMIT_CPU)
        print('Main_cpu_time used: {} | child_cpu_time used: {}\n'.format(cpu_time, child_time))
        print('cpu_time_limit: {}'.format(current))
        try:
            setrlimit(RLIMIT_CPU, (cpu_time+300, current[1]))
            clf.fit(X,y)
            cv_scores = cross_val_score(clf, X, y)
        except Exception as e:
            print('some thing wrong',e)
        finally:
            setrlimit(RLIMIT_CPU, current)
```


## What are the relevant issues?

#300 


