### PR TITLE
Checking duplicated pipeline in TPOT optimization process

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -561,15 +561,17 @@ class TPOTBase(BaseEstimator):
             # Fix random state when the operator allows
             self._set_param_recursive(sklearn_pipeline.steps, 'random_state', 42)
 
-            # Count the number of pipeline operators as a measure of pipeline covamplexity
+            # Count the number of pipeline operators as a measure of pipeline complexity
             operator_count = 0
 
-            #print('individual', individual)
-            #print('individual dir', dir(individual))
-            #print('individual fitness', individual.fitness.values)
+            # check if the individual are evaluated before
             if self.eval_ind.count(individual):
+                # get fitness score from previous evaluation
                 ind = self.eval_ind[self.eval_ind.index(individual)]
                 operator_count, resulting_score = ind.fitness.values
+                if self.verbosity == 3:
+                    self._pbar.write("Pipeline #{0} has been evaluated in a previous generation. "
+                    "Continue to the next pipeline.".format(self._pbar.n + 1))
             else:
                 # add time limit for evaluation of pipeline
                 for i in range(len(individual)):
@@ -588,11 +590,12 @@ class TPOTBase(BaseEstimator):
                 except TypeError:
                     raise TypeError('Warning: cv_scores is None due to timeout during evaluation of pipeline')
 
-        except Exception:
+        except Exception as e:
             # Catch-all: Do not allow one pipeline that crashes to cause TPOT
             # to crash. Instead, assign the crashing pipeline a poor fitness
             # import traceback
             # traceback.print_exc()
+            print(e)
             return 5000., -float('inf')
         finally:
             if not self._pbar.disable:

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -354,8 +354,9 @@ class TPOTBase(BaseEstimator):
                 for pipeline, pipeline_scores in zip(self._hof.items, reversed(self._hof.keys)):
                     if pipeline_scores.wvalues[1] > top_score:
                         self._optimized_pipeline = pipeline
-
-                if not self._optimized_pipeline:
+                # It won't raise error for a small test like in a unit test becasue a few pipeline sometimes
+                # may fail due to the training data does not fit the operator's requirement. 
+                if self.generations*self.population_size > 5 and not self._optimized_pipeline:
                     raise ValueError('There was an error in the TPOT optimization '
                                      'process. This could be because the data was '
                                      'not formatted properly, or because data for '

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -169,7 +169,7 @@ class TPOTBase(BaseEstimator):
 
         self._pbar = None
         self._gp_generation = 0
-        # a dictionary of individual which has already evaluated in previous generation
+        # a dictionary of individual which has already evaluated in previous generation.
         self.eval_ind = {}
 
         self.random_state = random_state

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -1,0 +1,174 @@
+"""
+Copyright 2016 Randal S. Olson
+
+his file is modified based on codes for alogrithms.eaSimple module in DEAP.
+
+This file is part of the TPOT library.
+
+The TPOT library is free software: you can redistribute it and/or
+modify it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your option)
+any later version.
+
+The TPOT library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+details. You should have received a copy of the GNU General Public License along
+with the TPOT library. If not, see http://www.gnu.org/licenses/.
+"""
+
+import random
+
+from deap import tools
+
+def varAnd(population, toolbox, cxpb, mutpb):
+    """Part of an evolutionary algorithm applying only the variation part
+    (crossover **and** mutation). The modified individuals have their
+    fitness invalidated. The individuals are cloned so returned population is
+    independent of the input population.
+    :param population: A list of individuals to vary.
+    :param toolbox: A :class:`~deap.base.Toolbox` that contains the evolution
+                    operators.
+    :param cxpb: The probability of mating two individuals.
+    :param mutpb: The probability of mutating an individual.
+    :returns: A list of varied individuals that are independent of their
+              parents.
+    The variation goes as follow. First, the parental population
+    :math:`P_\mathrm{p}` is duplicated using the :meth:`toolbox.clone` method
+    and the result is put into the offspring population :math:`P_\mathrm{o}`.
+    A first loop over :math:`P_\mathrm{o}` is executed to mate pairs of consecutive
+    individuals. According to the crossover probability *cxpb*, the
+    individuals :math:`\mathbf{x}_i` and :math:`\mathbf{x}_{i+1}` are mated
+    using the :meth:`toolbox.mate` method. The resulting children
+    :math:`\mathbf{y}_i` and :math:`\mathbf{y}_{i+1}` replace their respective
+    parents in :math:`P_\mathrm{o}`. A second loop over the resulting
+    :math:`P_\mathrm{o}` is executed to mutate every individual with a
+    probability *mutpb*. When an individual is mutated it replaces its not
+    mutated version in :math:`P_\mathrm{o}`. The resulting
+    :math:`P_\mathrm{o}` is returned.
+    This variation is named *And* beceause of its propention to apply both
+    crossover and mutation on the individuals. Note that both operators are
+    not applied systematicaly, the resulting individuals can be generated from
+    crossover only, mutation only, crossover and mutation, and reproduction
+    according to the given probabilities. Both probabilities should be in
+    :math:`[0, 1]`.
+    """
+    offspring = [toolbox.clone(ind) for ind in population]
+
+    # Apply crossover and mutation on the offspring
+    for i in range(1, len(offspring), 2):
+        if random.random() < cxpb:
+            ind1, ind2 = str(offspring[i - 1]), str(offspring[i])
+            offspring[i - 1], offspring[i] = toolbox.mate(offspring[i - 1], offspring[i])
+            for child in [offspring[i - 1], offspring[i]]:
+                # check if child is the same as their parents
+                if str(child) != ind1 and str(child) != ind2:
+                    del child.fitness.values
+
+    for i in range(len(offspring)):
+        if random.random() < mutpb:
+            tmpind = str(offspring[i])
+            offspring[i], = toolbox.mutate(offspring[i])
+            if tmpind != str(offspring[i]):
+                del offspring[i].fitness.values
+
+    return offspring
+
+
+def eaSimple(population, toolbox, cxpb, mutpb, ngen, stats=None,
+             halloffame=None, verbose=__debug__):
+    """This algorithm reproduce the simplest evolutionary algorithm as
+    presented in chapter 7 of [Back2000]_.
+    :param population: A list of individuals.
+    :param toolbox: A :class:`~deap.base.Toolbox` that contains the evolution
+                    operators.
+    :param cxpb: The probability of mating two individuals.
+    :param mutpb: The probability of mutating an individual.
+    :param ngen: The number of generation.
+    :param stats: A :class:`~deap.tools.Statistics` object that is updated
+                  inplace, optional.
+    :param halloffame: A :class:`~deap.tools.HallOfFame` object that will
+                       contain the best individuals, optional.
+    :param verbose: Whether or not to log the statistics.
+    :returns: The final population
+    :returns: A class:`~deap.tools.Logbook` with the statistics of the
+              evolution
+    The algorithm takes in a population and evolves it in place using the
+    :meth:`varAnd` method. It returns the optimized population and a
+    :class:`~deap.tools.Logbook` with the statistics of the evolution. The
+    logbook will contain the generation number, the number of evalutions for
+    each generation and the statistics if a :class:`~deap.tools.Statistics` is
+    given as argument. The *cxpb* and *mutpb* arguments are passed to the
+    :func:`varAnd` function. The pseudocode goes as follow ::
+        evaluate(population)
+        for g in range(ngen):
+            population = select(population, len(population))
+            offspring = varAnd(population, toolbox, cxpb, mutpb)
+            evaluate(offspring)
+            population = offspring
+    As stated in the pseudocode above, the algorithm goes as follow. First, it
+    evaluates the individuals with an invalid fitness. Second, it enters the
+    generational loop where the selection procedure is applied to entirely
+    replace the parental population. The 1:1 replacement ratio of this
+    algorithm **requires** the selection procedure to be stochastic and to
+    select multiple times the same individual, for example,
+    :func:`~deap.tools.selTournament` and :func:`~deap.tools.selRoulette`.
+    Third, it applies the :func:`varAnd` function to produce the next
+    generation population. Fourth, it evaluates the new individuals and
+    compute the statistics on this population. Finally, when *ngen*
+    generations are done, the algorithm returns a tuple with the final
+    population and a :class:`~deap.tools.Logbook` of the evolution.
+    .. note::
+        Using a non-stochastic selection method will result in no selection as
+        the operator selects *n* individuals from a pool of *n*.
+    This function expects the :meth:`toolbox.mate`, :meth:`toolbox.mutate`,
+    :meth:`toolbox.select` and :meth:`toolbox.evaluate` aliases to be
+    registered in the toolbox.
+    .. [Back2000] Back, Fogel and Michalewicz, "Evolutionary Computation 1 :
+       Basic Algorithms and Operators", 2000.
+    """
+    logbook = tools.Logbook()
+    logbook.header = ['gen', 'nevals'] + (stats.fields if stats else [])
+
+    # Evaluate the individuals with an invalid fitness
+    invalid_ind = [ind for ind in population if not ind.fitness.valid]
+    fitnesses = toolbox.map(toolbox.evaluate, invalid_ind)
+    for ind, fit in zip(invalid_ind, fitnesses):
+        ind.fitness.values = fit
+
+    if halloffame is not None:
+        halloffame.update(population)
+
+    record = stats.compile(population) if stats else {}
+    logbook.record(gen=0, nevals=len(invalid_ind), **record)
+    if verbose:
+        print(logbook.stream)
+
+    # Begin the generational process
+    for gen in range(1, ngen + 1):
+        # Select the next generation individuals
+        offspring = toolbox.select(population, len(population))
+
+        # Vary the pool of individuals
+        offspring = varAnd(offspring, toolbox, cxpb, mutpb)
+
+        # Evaluate the individuals with an invalid fitness
+        invalid_ind = [ind for ind in offspring if not ind.fitness.valid]
+        fitnesses = toolbox.map(toolbox.evaluate, invalid_ind)
+        for ind, fit in zip(invalid_ind, fitnesses):
+            ind.fitness.values = fit
+
+        # Update the hall of fame with the generated individuals
+        if halloffame is not None:
+            halloffame.update(offspring)
+
+        # Replace the current population by the offspring
+        population[:] = offspring
+
+        # Append the current generation statistics to the logbook
+        record = stats.compile(population) if stats else {}
+        logbook.record(gen=gen, nevals=len(invalid_ind), **record)
+        if verbose:
+            print(logbook.stream)
+
+    return population, logbook


### PR DESCRIPTION
## What does this PR do?

In the source codes of [algorithms.eaSimplie](https://github.com/DEAP/deap/blob/master/deap/algorithms.py) in deap, the fitness.values were removed during generating offsprings in each generation by crossover or mutation. So these pipeline generated by crossover and mutation need be evaluated again in the new generation. However, if the diversity of pipelines are limited by customizing used operators. Many duplicated pipelines can be generated over generations. Evaluating the same pipelines is worthless. So in this RP, a list of evaluated individual is added. In each time of pipeline evaluation, the pipeline must be checked first whether it is evaluated before. If so, its fitness scores are assigned with that in previous evaluations. The way can speed up a lot TPOT pipeline optimization process in later generations. 

## Where should the reviewer start?

Line ~560 in base.py 

## How should this PR be tested?

```
from tpot import TPOTClassifier
from sklearn.datasets import load_digits
from sklearn.model_selection import train_test_split

digits = load_digits()
X_train, X_test, y_train, y_test = train_test_split(digits.data, digits.target,
                                                    train_size=0.10, test_size=0.90)

tpot = TPOTClassifier(generations=5, population_size=20, verbosity=3)
tpot.fit(X_train, y_train)
print(tpot.score(X_test, y_test))

```



## What are the relevant issues?

#303 


