### PR TITLE
Adding sample_weight argument into tpot.fit()

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -168,6 +168,29 @@ def test_score_3():
 
     assert isclose(known_score, score)
 
+def test_sample_weight_func():
+    """Assert that the TPOTRegressor score function outputs a known score for a fixed pipeline with sample weights"""
+
+    tpot_obj = TPOTRegressor(scoring='neg_mean_squared_error')
+    tpot_obj._pbar = tqdm(total=1, disable=True)
+    known_score = 9.61954007496  # Assumes use of mse
+    # Reify pipeline with known score
+    tpot_obj._optimized_pipeline = creator.Individual.\
+        from_string('ExtraTreesRegressor(GradientBoostingRegressor(input_matrix, 100.0, 0.11), 0.17999999999999999)', tpot_obj._pset)
+    tpot_obj._fitted_pipeline = tpot_obj._toolbox.compile(expr=tpot_obj._optimized_pipeline)
+    # make up a sample weight
+    training_classes_r_weight = range(1, len(training_classes_r)+1)
+    training_classes_r_weight_dict = tpot_obj._set_param_recursive(tpot_obj._fitted_pipeline .steps, 'random_state', 42, training_classes_r_weight)
+    tpot_obj._fitted_pipeline.fit(training_features_r, training_classes_r, **training_classes_r_weight_dict)
+
+    # Get score from TPOT
+    score = tpot_obj.score(testing_features_r, testing_classes_r)
+    # http://stackoverflow.com/questions/5595425/
+    def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
+        return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+
+    assert isclose(known_score, score)
+
 
 def test_predict():
     """Assert that the TPOT predict function raises a ValueError when no optimized pipeline exists"""

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -38,8 +38,6 @@ from sklearn.preprocessing import FunctionTransformer
 from sklearn.ensemble import VotingClassifier
 from sklearn.metrics.scorer import make_scorer
 
-from inspect import getargspec
-
 from update_checker import update_check
 
 from ._version import __version__
@@ -65,7 +63,9 @@ if sys.platform.startswith('win'):
         return 0
     win32api.SetConsoleCtrlHandler(handler, 1)
 # add time limit for imported function
+print(inspect.getargspec(cross_val_score).args)
 cross_val_score = _timeout(cross_val_score)
+
 
 class TPOTBase(BaseEstimator):
     """TPOT automatically creates and optimizes machine learning pipelines using genetic programming"""
@@ -619,8 +619,8 @@ class TPOTBase(BaseEstimator):
         except Exception:
             # Catch-all: Do not allow one pipeline that crashes to cause TPOT
             # to crash. Instead, assign the crashing pipeline a poor fitness
-            import traceback
-            traceback.print_exc()
+            # import traceback
+            # traceback.print_exc()
             return 5000., -float('inf')
         finally:
             if not self._pbar.disable:

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -63,7 +63,6 @@ if sys.platform.startswith('win'):
         return 0
     win32api.SetConsoleCtrlHandler(handler, 1)
 # add time limit for imported function
-print(inspect.getargspec(cross_val_score).args)
 cross_val_score = _timeout(cross_val_score)
 
 

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -619,8 +619,8 @@ class TPOTBase(BaseEstimator):
         except Exception:
             # Catch-all: Do not allow one pipeline that crashes to cause TPOT
             # to crash. Instead, assign the crashing pipeline a poor fitness
-            # import traceback
-            # traceback.print_exc()
+            import traceback
+            traceback.print_exc()
             return 5000., -float('inf')
         finally:
             if not self._pbar.disable:


### PR DESCRIPTION
## What does this PR do?

Make TPOT work with sample weights.

## Where should the reviewer start?

Line 527 in base.py

## How should this PR be tested?

```
from tpot import TPOTClassifier
from sklearn.datasets import load_digits
from sklearn.model_selection import train_test_split

digits = load_digits()
X_train, X_test, y_train, y_test = train_test_split(digits.data, digits.target,
                                                            train_size=0.10, test_size=0.90)

sample_weight = range(1, len(y_train) + 1) # made-up weights

tpot = TPOTClassifier(generations=5, crossover_rate= 0.5, population_size=20)
tpot.fit(X_train, y_train, sample_weight=sample_weight)
print(tpot.score(X_test, y_test))
```


## What are the relevant issues?

#310 

## Questions:

I wil add a unit test for this function soon.

