### PR TITLE
Add -1 Option in n_jobs

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -739,7 +739,10 @@ class TPOTBase(BaseEstimator):
             return resulting_score
 
         if not sys.platform.startswith('win'):
-            pool = ProcessPool(nodes=self.n_jobs)
+            if self.n_jobs == -1:
+                pool = ProcessPool()
+            else:
+                pool = ProcessPool(nodes=self.n_jobs)
             res_imap = pool.imap(_wrapped_cross_val_score, sklearn_pipeline_list)
             if not self._pbar.disable:
                 ini_pbar_n = self._pbar.n


### PR DESCRIPTION
Add `-1` option in `n_jobs` to use all CPU in one compute node for running TPOT