### PR TITLE
_pre_test decorator

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -320,9 +320,9 @@ class TPOTBase(BaseEstimator):
         self._toolbox.register('population', tools.initRepeat, list, self._toolbox.individual)
         self._toolbox.register('compile', self._compile_to_sklearn)
         self._toolbox.register('select', tools.selNSGA2)
-        self._toolbox.register('mate', _pre_test(gp.cxOnePoint))
+        self._toolbox.register('mate', self._mate_operator)
         self._toolbox.register('expr_mut', self._gen_grow_safe, min_=1, max_=4)
-        self._toolbox.register('mutate', _pre_test(self._random_mutation_operator))
+        self._toolbox.register('mutate', self._random_mutation_operator)
 
     def fit(self, features, classes, sample_weight=None):
         """Fits a machine learning pipeline that maximizes classification score
@@ -788,7 +788,11 @@ class TPOTBase(BaseEstimator):
             fitnesses_ordered.append(fitnesses_dict[key])
         return fitnesses_ordered
 
+    @_pre_test
+    def _mate_operator(self, ind1, ind2):
+        return gp.cxOnePoint(ind1, ind2)
 
+    @_pre_test
     def _random_mutation_operator(self, individual):
         """Perform a replacement, insert, or shrink mutation on an individual
 

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -810,15 +810,12 @@ class TPOTBase(BaseEstimator):
         """
         # debug usage
         #print(str(individual))
-        old_ind = str(individual)
-        mut_ind = (str(individual),)
         mutation_techniques = [
             partial(gp.mutInsert, pset=self._pset),
             partial(mutNodeReplacement, pset=self._pset),
             partial(gp.mutShrink)
         ]
-        mut_ind = np.random.choice(mutation_techniques)(individual)
-        return mut_ind
+        return np.random.choice(mutation_techniques)(individual)
 
 
     def _gen_grow_safe(self, pset, min_, max_, type_=None):

--- a/tpot/decorators.py
+++ b/tpot/decorators.py
@@ -24,6 +24,7 @@ import sys
 import warnings
 from sklearn.datasets import make_classification, make_regression
 from .export_utils import expr_to_tree, generate_pipeline_code
+from deap import creator
 # generate a small data set for a new pipeline, in order to check if the pipeline
 # has unsuppported combinations in params
 pretest_X, pretest_y = make_classification(n_samples=50, n_features=10, random_state=42)
@@ -141,6 +142,8 @@ def _pre_test(func):
         bad_pipeline = True
         num_test = 0 # number of tests
         while bad_pipeline and num_test < 10: # a pool for workable pipeline
+            # clone individual before each func call so it is not altered for the possible next cycle loop
+            args = [self._toolbox.clone(arg) if isinstance(arg, creator.Individual) else arg for arg in args]
             try:
                 with warnings.catch_warnings():
                     warnings.simplefilter('ignore')

--- a/tpot/decorators.py
+++ b/tpot/decorators.py
@@ -145,13 +145,16 @@ def _pre_test(func):
                 with warnings.catch_warnings():
                     warnings.simplefilter('ignore')
                     expr = func(self, *args, **kwargs)
-                    #print(num_test, generate_pipeline_code(expr_to_tree(expr), self.operators)) # debug
-                    sklearn_pipeline = eval(generate_pipeline_code(expr_to_tree(expr), self.operators), self.operators_context)
-                    if self.classification:
-                        sklearn_pipeline.fit(pretest_X, pretest_y)
-                    else:
-                        sklearn_pipeline.fit(pretest_X_reg, pretest_y_reg)
-                    bad_pipeline = False
+                    # mutation operator returns tuple (ind,); crossover operator returns tuple (ind1, ind2)
+                    expr_tuple = expr if isinstance(expr, tuple) else (expr,)
+                    for expr_test in expr_tuple:
+                        #print(num_test, generate_pipeline_code(expr_to_tree(expr), self.operators)) # debug
+                        sklearn_pipeline = eval(generate_pipeline_code(expr_to_tree(expr_test), self.operators), self.operators_context)
+                        if self.classification:
+                            sklearn_pipeline.fit(pretest_X, pretest_y)
+                        else:
+                            sklearn_pipeline.fit(pretest_X_reg, pretest_y_reg)
+                        bad_pipeline = False
             except:
                 pass
             finally:

--- a/tpot/decorators.py
+++ b/tpot/decorators.py
@@ -155,7 +155,9 @@ def _pre_test(func):
                         else:
                             sklearn_pipeline.fit(pretest_X_reg, pretest_y_reg)
                         bad_pipeline = False
-            except:
+            except BaseException as e:
+                if self.verbosity == 3:
+                    print('_pre_test decorator: {fname}: num_test={n} {e}'.format(n=num_test, fname=func.__name__, e=e))
                 pass
             finally:
                 num_test += 1

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -59,16 +59,22 @@ def varOr(population, toolbox, lambda_, cxpb, mutpb):
             idxs = np.random.randint(0, len(population),size=2)
             ind1, ind2 = toolbox.clone(population[idxs[0]]), toolbox.clone(population[idxs[1]])
             ind_str = str(ind1)
-            ind1, ind2 = toolbox.mate(ind1, ind2)
-            if ind_str != str(ind1): # check if crossover generated a new pipeline
+            num_loop = 0
+            while ind_str == str(ind1) and num_loop < 50 : # 50 loops at most to generate a different individual by crossover
+                ind1, ind2 = toolbox.mate(ind1, ind2)
+                num_loop += 1
+            if ind_str != str(ind1): # check if crossover happened
                 del ind1.fitness.values
             offspring.append(ind1)
         elif op_choice < cxpb + mutpb:  # Apply mutation
             idx = np.random.randint(0, len(population))
             ind = toolbox.clone(population[idx])
             ind_str = str(ind)
-            ind, = toolbox.mutate(ind)
-            if ind_str != str(ind): # check if mutation happend
+            num_loop = 0
+            while ind_str == str(ind) and num_loop < 50 : # 50 loops at most to generate a different individual by mutation
+                ind, = toolbox.mutate(ind)
+                num_loop += 1
+            if ind_str != str(ind): # check if mutation happened
                 del ind.fitness.values
             offspring.append(ind)
         else: # Apply reproduction


### PR DESCRIPTION
## What does this PR do?

1. Uses `_pre_test`  to decorate class functions of `TPOTBase` and not only to be called when registering mate/mutate functions. Adds a wrapper around `gp.cxOnePoint(ind1, ind2)` so that the wrapper can be decorated with `_pre_test`. This ensures that operator's arguments are all passed into the decorator, including `self` argument.

2. Adds support for evaluation of both Individual and tuple of Individuals as a result of decorated function.

3. Adds debug printout to show any exceptions inside the decorator. 

## Where should the reviewer start?

- ` _pre_test` function in `decorators.py`
- `_setup_toolbox` in `base.py`

## How should this PR be tested?

Any TPOT example

## What are the relevant issues?
#366 
#368