### PR TITLE
Avoid using multiprocessing when n_jobs ==1

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -248,7 +248,7 @@ def test_score_3():
     """Assert that the TPOTRegressor score function outputs a known score for a fix pipeline"""
 
     tpot_obj = TPOTRegressor(scoring='neg_mean_squared_error')
-    known_score = 11.2010824752 # Assumes use of mse
+    known_score = 12.3727966005 # Assumes use of mse
 
     # Reify pipeline with known score
 
@@ -257,15 +257,16 @@ def test_score_3():
         "GradientBoostingRegressor__learning_rate=0.1,GradientBoostingRegressor__loss=huber,"
         "GradientBoostingRegressor__max_depth=5, GradientBoostingRegressor__max_features=0.5,"
         "GradientBoostingRegressor__min_samples_leaf=5, GradientBoostingRegressor__min_samples_split=5,"
-        "GradientBoostingRegressor__subsample=0.25),"
-        "ExtraTreesRegressor__bootstrap=True,ExtraTreesRegressor__max_features=0.5,"
-        "ExtraTreesRegressor__min_samples_leaf=5,ExtraTreesRegressor__min_samples_split=5)")
+        "GradientBoostingRegressor__n_estimators=100, GradientBoostingRegressor__subsample=0.25),"
+        "ExtraTreesRegressor__bootstrap=True, ExtraTreesRegressor__max_features=0.5,"
+        "ExtraTreesRegressor__min_samples_leaf=5, ExtraTreesRegressor__min_samples_split=5, "
+        "ExtraTreesRegressor__n_estimators=100)")
     tpot_obj._optimized_pipeline = creator.Individual.from_string(pipeline_string, tpot_obj._pset)
     tpot_obj._fitted_pipeline = tpot_obj._toolbox.compile(expr=tpot_obj._optimized_pipeline)
     tpot_obj._fitted_pipeline.fit(training_features_r, training_classes_r)
-
     # Get score from TPOT
     score = tpot_obj.score(testing_features_r, testing_classes_r)
+
 
     # http://stackoverflow.com/questions/5595425/
     def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
@@ -285,9 +286,14 @@ def test_sample_weight_func():
         "GradientBoostingRegressor__learning_rate=0.1,GradientBoostingRegressor__loss=huber,"
         "GradientBoostingRegressor__max_depth=5, GradientBoostingRegressor__max_features=0.5,"
         "GradientBoostingRegressor__min_samples_leaf=5, GradientBoostingRegressor__min_samples_split=5,"
-        "GradientBoostingRegressor__subsample=0.25),"
-        "ExtraTreesRegressor__bootstrap=True,ExtraTreesRegressor__max_features=0.5,"
-        "ExtraTreesRegressor__min_samples_leaf=5,ExtraTreesRegressor__min_samples_split=5)")
+        "GradientBoostingRegressor__n_estimators=100, GradientBoostingRegressor__subsample=0.25),"
+        "ExtraTreesRegressor__bootstrap=True, ExtraTreesRegressor__max_features=0.5,"
+        "ExtraTreesRegressor__min_samples_leaf=5, ExtraTreesRegressor__min_samples_split=5, "
+        "ExtraTreesRegressor__n_estimators=100)")
+    tpot_obj._optimized_pipeline = creator.Individual.from_string(pipeline_string, tpot_obj._pset)
+    tpot_obj._fitted_pipeline = tpot_obj._toolbox.compile(expr=tpot_obj._optimized_pipeline)
+    tpot_obj._fitted_pipeline.fit(training_features_r, training_classes_r)
+
     tpot_obj._optimized_pipeline = creator.Individual.from_string(pipeline_string, tpot_obj._pset)
     tpot_obj._fitted_pipeline = tpot_obj._toolbox.compile(expr=tpot_obj._optimized_pipeline)
 
@@ -307,7 +313,7 @@ def test_sample_weight_func():
     np.random.seed(42)
     tpot_obj._fitted_pipeline.fit(training_features_r, training_classes_r, **training_classes_r_weight_dict)
     # Get score from TPOT
-    known_score = 14.1377471426 # Assumes use of mse
+    known_score = 12.643383517 # Assumes use of mse
     score = tpot_obj.score(testing_features_r, testing_classes_r)
 
     # http://stackoverflow.com/questions/5595425/
@@ -502,7 +508,7 @@ def test_generate_pipeline_code():
     expected_code = """make_pipeline(
     make_union(
         make_union(VotingClassifier([('branch',
-            GradientBoostingClassifier(learning_rate=38.0, max_depth=5, max_features=5, min_samples_leaf=5, min_samples_split=0.05, subsample=0.5)
+            GradientBoostingClassifier(learning_rate=38.0, max_depth=5, max_features=5, min_samples_leaf=5, min_samples_split=0.05, n_estimators=0.5)
         )]), FunctionTransformer(lambda X: X)),
         make_union(VotingClassifier([('branch',
             make_pipeline(

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -727,36 +727,30 @@ class TPOTBase(BaseEstimator):
                 resulting_score = -float('inf')
             return resulting_score
 
-        if self.n_jobs != 1:
-            pool = Pool(processes=self.n_jobs)
-            resulting_score_list = []
-            # chunk size for pbar update
-            for chunk_idx in range(0, len(sklearn_pipeline_list),self.n_jobs*2):
+        # evalurate pipeline
+
+        resulting_score_list = []
+        # chunk size for pbar update
+        for chunk_idx in range(0, len(sklearn_pipeline_list),self.n_jobs*2):
+            if self.n_jobs != 1:
+                pool = Pool(processes=self.n_jobs)
                 tmp_result_score = pool.map(_wrapped_cross_val_score, sklearn_pipeline_list[chunk_idx:chunk_idx+self.n_jobs*2])
-                for val in tmp_result_score:
-                    if not self._pbar.disable:
-                        self._pbar.update(1)
-                    if val == 'Timeout':
-                        if self.verbosity > 2:
-                            self._pbar.write('Skipped pipeline #{0} due to time out. '
-                                             'Continuing to the next pipeline.'.format(self._pbar.n))
-                        resulting_score_list.append(-float('inf'))
-                    else:
-                        resulting_score_list.append(val)
-            pool.terminate() 
-        else:
-            resulting_score_list = []
-            for sklearn_pipeline in sklearn_pipeline_list:
-                try:
-                    resulting_score = _wrapped_cross_val_score(sklearn_pipeline)
-                except TimedOutExc:
-                    resulting_score = -float('inf')
-                    if self.verbosity > 2 and not self._pbar.disable:
-                        self._pbar.write('Skipped pipeline #{0} due to time out. '
-                                         'Continuing to the next pipeline.'.format(self._pbar.n + 1))
-                resulting_score_list.append(resulting_score)
+                pool.terminate() # garbage collection
+            else:
+                tmp_result_score = map(_wrapped_cross_val_score, sklearn_pipeline_list[chunk_idx:chunk_idx+self.n_jobs*2])
+            # update pbar
+            for val in tmp_result_score:
                 if not self._pbar.disable:
                     self._pbar.update(1)
+                if val == 'Timeout':
+                    if self.verbosity > 2:
+                        self._pbar.write('Skipped pipeline #{0} due to time out. '
+                                         'Continuing to the next pipeline.'.format(self._pbar.n))
+                    resulting_score_list.append(-float('inf'))
+                else:
+                    resulting_score_list.append(val)
+
+
 
         for resulting_score, operator_count, individual_str, test_idx in zip(resulting_score_list, operator_count_list, eval_individuals_str, test_idx_list):
             if type(resulting_score) in [float, np.float64, np.float32]:

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -727,7 +727,7 @@ class TPOTBase(BaseEstimator):
                 resulting_score = -float('inf')
             return resulting_score
 
-        if not sys.platform.startswith('win'):
+        if self.n_jobs != 1:
             pool = Pool(processes=self.n_jobs)
             resulting_score_list = []
             # chunk size for pbar update
@@ -743,6 +743,7 @@ class TPOTBase(BaseEstimator):
                         resulting_score_list.append(-float('inf'))
                     else:
                         resulting_score_list.append(val)
+            pool.terminate() 
         else:
             resulting_score_list = []
             for sklearn_pipeline in sklearn_pipeline_list:

--- a/tpot/decorators.py
+++ b/tpot/decorators.py
@@ -74,6 +74,8 @@ def _timeout(max_eval_time_mins=5):
             import signal
             @wraps(func)
             def limitedTime(*args, **kw):
+                # don't show traceback
+                sys.tracebacklimit=0
                 old_signal_hander = signal.signal(signal.SIGALRM, timeout_signal_handler)
                 max_time_seconds = convert_mins_to_secs(max_eval_time_mins)
                 signal.alarm(max_time_seconds)
@@ -81,11 +83,12 @@ def _timeout(max_eval_time_mins=5):
                     with warnings.catch_warnings():
                         warnings.simplefilter('ignore')
                         ret = func(*args, **kw)
-                except:
+                except TimedOutExc:
                     raise TimedOutExc('Time Out!')
                 finally:
                     signal.signal(signal.SIGALRM, old_signal_hander)  # Old signal handler is restored
                     signal.alarm(0)  # Alarm removed
+                    sys.tracebacklimit=1000
                 return ret
         else:
             class InterruptableThread(threading.Thread):


### PR DESCRIPTION
Fix 3 unit tests due to new dictionary 

multiprocessing can not be used when n_jobs==1
