### PR TITLE
A patch to replace gp.cxOnePoint for solving the reproducibility issue with a given random seed

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -748,6 +748,8 @@ class TPOTBase(BaseEstimator):
     @_pre_test
     def _mate_operator(self, ind1, ind2):
         #return gp.cxOnePoint(ind1, ind2)
+        # disable gp.cxOnePoint(ind1, ind2) due to a bug related to random_state
+        # may reuse it if deap fix the bug
         return cxOnePoint(ind1, ind2)
 
     @_pre_test

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -53,7 +53,7 @@ from .built_in_operators import CombineDFs
 
 from .metrics import SCORERS
 from .gp_types import Output_Array
-from .gp_deap import eaMuPlusLambda, mutNodeReplacement, _wrapped_cross_val_score
+from .gp_deap import eaMuPlusLambda, mutNodeReplacement, _wrapped_cross_val_score, cxOnePoint
 
 # hot patch for Windows: solve the problem of crashing python after Ctrl + C in Windows OS
 if sys.platform.startswith('win'):
@@ -747,7 +747,8 @@ class TPOTBase(BaseEstimator):
 
     @_pre_test
     def _mate_operator(self, ind1, ind2):
-        return gp.cxOnePoint(ind1, ind2)
+        #return gp.cxOnePoint(ind1, ind2)
+        return cxOnePoint(ind1, ind2)
 
     @_pre_test
     def _random_mutation_operator(self, individual):

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -47,7 +47,6 @@ from update_checker import update_check
 from ._version import __version__
 from .operator_utils import TPOTOperatorClassFactory, Operator, ARGType
 from .export_utils import export_pipeline, expr_to_tree, generate_pipeline_code
-#from .decorators import _timeout, _pre_test, TimedOutExc
 from .decorators import _pre_test
 from .built_in_operators import CombineDFs
 
@@ -747,9 +746,6 @@ class TPOTBase(BaseEstimator):
 
     @_pre_test
     def _mate_operator(self, ind1, ind2):
-        #return gp.cxOnePoint(ind1, ind2)
-        # disable gp.cxOnePoint(ind1, ind2) due to a bug related to random_state
-        # may reuse it if deap fix the bug
         return cxOnePoint(ind1, ind2)
 
     @_pre_test
@@ -768,8 +764,6 @@ class TPOTBase(BaseEstimator):
             Returns the individual with one of the mutations applied to it
 
         """
-        # debug usage
-        #print(str(individual))
         mutation_techniques = [
             partial(gp.mutInsert, pset=self._pset),
             partial(mutNodeReplacement, pset=self._pset),

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -232,7 +232,7 @@ def cxOnePoint(ind1, ind2):
         common_types = [x for x in types1 if x in types2]
 
     if len(common_types) > 0:
-        type_ = np.random.choice(list(common_types))
+        type_ = np.random.choice(common_types)
 
         index1 = np.random.choice(types1[type_])
         index2 = np.random.choice(types2[type_])

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -24,6 +24,7 @@ from inspect import isclass
 from .operator_utils import set_sample_weight
 from sklearn.model_selection import cross_val_score
 from sklearn.base import clone
+from collections import defaultdict
 import warnings
 import threading
 
@@ -199,9 +200,6 @@ def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen, pbar,
 
     return population, logbook
 
-
-####
-from collections import defaultdict
 
 def cxOnePoint(ind1, ind2):
     """Randomly select in each individual and exchange each subtree with the

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -327,7 +327,6 @@ class Interruptable_cross_val_score(threading.Thread):
                 warnings.simplefilter('ignore')
                 self.result = cross_val_score(*self.args, **self.kwargs)
         except Exception as e:
-            #print(e) # for debug use
             pass
 
 def _wrapped_cross_val_score(sklearn_pipeline, features, classes,

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -229,8 +229,8 @@ def cxOnePoint(ind1, ind2):
         for idx, node in enumerate(ind2[1:], 1):
             types2[node.ret].append(idx)
 
-        common_types = [x for x in types1 if x in types2]
-
+        common_types = [x for x in list(types1.keys()) if x in list(types2.keys())]
+        print('    >>>> check types', common_types)
     if len(common_types) > 0:
         type_ = np.random.choice(common_types)
 

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -229,8 +229,8 @@ def cxOnePoint(ind1, ind2):
         for idx, node in enumerate(ind2[1:], 1):
             types2[node.ret].append(idx)
 
-        common_types = [x for x in list(types1.keys()) if x in list(types2.keys())]
-        print('    >>>> check types', common_types)
+        common_types = [x for x in types1 if x in types2]
+
     if len(common_types) > 0:
         type_ = np.random.choice(common_types)
 


### PR DESCRIPTION
[please review the [contribution guidelines](http://rhiever.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]

## What does this PR do?

Replace `gp.cxOnePoint` in base.py to make TPOT can reproduce results with a given random seed. This issue is caused by using unordered data structure `set()` when mating two patients. The issue is also posted on [deap repo](https://github.com/DEAP/deap/issues/190)

## Where should the reviewer start?

gp_deap.py

## How should this PR be tested?

Run any TPOT examples multiple times with a fixed random seed

## What are the relevant issues?
 #392 
[Issue 190 on deap](https://github.com/DEAP/deap/issues/190)

