### PR TITLE
Correct deap version to 1.0.2.post2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-deap==1.0.2
+deap==1.0.2.post2
 nose==1.3.7
 numpy==1.12.1
 scikit-learn==0.18.1


### PR DESCRIPTION
```
pip install deap==1.0.2
Collecting deap==1.0.2
  Could not find a version that satisfies the requirement deap==1.0.2 (from versions: 0.9.1, 0.9.2, 1.0.0rc3, 1.0.0, 1.0.1, 1.0.2.post2)
No matching distribution found for deap==1.0.2

pip install deap==1.0.2.post2
Collecting deap==1.0.2.post2
Installing collected packages: deap
Successfully installed deap-1.0.2

```

So I changed 1.0.2 to 1.0.2.post2

Related issue: #434 #433 