### PR TITLE
Turn off stdout when verbosity < 3

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -24,6 +24,7 @@ import random
 import inspect
 import warnings
 import sys
+import os
 import imp
 from functools import partial
 from datetime import datetime
@@ -496,6 +497,12 @@ class TPOTBase(BaseEstimator):
         self._pbar = tqdm(total=total_evals, unit='pipeline', leave=False,
                           disable=not (self.verbosity >= 2), desc='Optimization Progress')
 
+        # disable stdout during optimization process
+        if self.verbosity < 3:
+            org_sysout = sys.stdout
+            f = open(os.devnull, 'w')
+            sys.stdout = f
+
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore')
@@ -527,7 +534,9 @@ class TPOTBase(BaseEstimator):
             # Standard truthiness checks won't work for tqdm
             if not isinstance(self._pbar, type(None)):
                 self._pbar.close()
-
+            # restore stdout
+            if self.verbosity < 3:
+                sys.stdout = org_sysout
             # Store the pipeline with the highest internal testing score
             if self._pareto_front:
                 top_score = -float('inf')

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -500,8 +500,7 @@ class TPOTBase(BaseEstimator):
         # disable stdout during optimization process
         if self.verbosity < 3:
             org_sysout = sys.stdout
-            f = open(os.devnull, 'w')
-            sys.stdout = f
+            sys.stdout = open(os.devnull, 'w')
 
         try:
             with warnings.catch_warnings():
@@ -534,7 +533,7 @@ class TPOTBase(BaseEstimator):
             # Standard truthiness checks won't work for tqdm
             if not isinstance(self._pbar, type(None)):
                 self._pbar.close()
-            # restore stdout
+            # restore sys.stdout
             if self.verbosity < 3:
                 sys.stdout = org_sysout
             # Store the pipeline with the highest internal testing score


### PR DESCRIPTION
Redirect stdout to null device in the system during optimization process to prevent the error message in stdout like the issue #449  
