### PR TITLE
Refine ZeroCount

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1047,11 +1047,11 @@ def test_float_range_3():
 
 def test_ZeroCount():
     """Assert that ZeroCount operator returns correct transformed X."""
-    X = np.array([[0,1,7,0,0],[3,0,0,2,19],[0,1,3,4,5],[5,0,0,0,0]])
+    X = np.array([[0, 1, 7, 0, 0], [3, 0, 0, 2, 19], [0, 1, 3, 4, 5], [5, 0, 0, 0, 0]])
     op = ZeroCount()
     X_transformed = op.transform(X)
-    zero_col = np.array([3,2,1,4])
-    non_zero = np.array([2,3,4,1])
+    zero_col = np.array([3, 2, 1, 4])
+    non_zero = np.array([2, 3, 4, 1])
     
-    assert np.allclose(zero_col, X_transformed[:,0])
-    assert np.allclose(non_zero, X_transformed[:,1])
+    assert np.allclose(zero_col, X_transformed[:, 0])
+    assert np.allclose(non_zero, X_transformed[:, 1])

--- a/tests.py
+++ b/tests.py
@@ -21,6 +21,7 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 
 from tpot import TPOTClassifier, TPOTRegressor
 from tpot.base import TPOTBase
+from tpot.built_in_operators import ZeroCount
 from tpot.driver import positive_integer, float_range, _get_arg_parser, _print_args, main, _read_data_file
 from tpot.export_utils import export_pipeline, generate_import_code, _indent, generate_pipeline_code, get_by_name
 from tpot.gp_types import Output_Array
@@ -1042,3 +1043,15 @@ def test_float_range_2():
 def test_float_range_3():
     """Assert that the TPOT CLI interface's float range throws an exception when input is not a float."""
     assert_raises(Exception, float_range, 'foobar')
+
+
+def test_ZeroCount():
+    """Assert that ZeroCount operator returns correct transformed X."""
+    X = np.array([[0,1,7,0,0],[3,0,0,2,19],[0,1,3,4,5],[5,0,0,0,0]])
+    op = ZeroCount()
+    X_transformed = op.transform(X)
+    zero_col = np.array([3,2,1,4])
+    non_zero = np.array([2,3,4,1
+    
+    assert np.allclose(zero_col, X_transformed[:,0])
+    assert np.allclose(non_zero, X_transformed[:,1])

--- a/tests.py
+++ b/tests.py
@@ -1051,7 +1051,7 @@ def test_ZeroCount():
     op = ZeroCount()
     X_transformed = op.transform(X)
     zero_col = np.array([3,2,1,4])
-    non_zero = np.array([2,3,4,1
+    non_zero = np.array([2,3,4,1])
     
     assert np.allclose(zero_col, X_transformed[:,0])
     assert np.allclose(non_zero, X_transformed[:,1])

--- a/tpot/built_in_operators.py
+++ b/tpot/built_in_operators.py
@@ -52,8 +52,8 @@ class ZeroCount(BaseEstimator, TransformerMixin):
 
         X_transformed = np.copy(X)
 
-        non_zero = np.reshape(np.count_nonzero(X_transformed, axis=1), (-1,1))
-        zero_col = np.reshape(n_features - np.count_nonzero(X_transformed, axis=1), (-1,1))
+        non_zero = np.reshape(np.count_nonzero(X_transformed, axis=1), (-1,1 ))
+        zero_col = np.reshape(n_features - np.count_nonzero(X_transformed, axis=1), (-1, 1))
 
         X_transformed = np.hstack((non_zero, X_transformed))
         X_transformed = np.hstack((zero_col, X_transformed))

--- a/tpot/built_in_operators.py
+++ b/tpot/built_in_operators.py
@@ -52,7 +52,7 @@ class ZeroCount(BaseEstimator, TransformerMixin):
 
         X_transformed = np.copy(X)
 
-        non_zero = np.reshape(np.count_nonzero(X_transformed, axis=1), (-1,1 ))
+        non_zero = np.reshape(np.count_nonzero(X_transformed, axis=1), (-1, 1))
         zero_col = np.reshape(n_features - np.count_nonzero(X_transformed, axis=1), (-1, 1))
 
         X_transformed = np.hstack((non_zero, X_transformed))

--- a/tpot/built_in_operators.py
+++ b/tpot/built_in_operators.py
@@ -52,8 +52,9 @@ class ZeroCount(BaseEstimator, TransformerMixin):
 
         X_transformed = np.copy(X)
 
-        non_zero = np.reshape(np.count_nonzero(X_transformed, axis=1), (-1, 1))
-        zero_col = np.reshape(n_features - np.count_nonzero(X_transformed, axis=1), (-1, 1))
+        non_zero_vector = np.count_nonzero(X_transformed, axis=1)
+        non_zero = np.reshape(non_zero_vector, (-1, 1))
+        zero_col = np.reshape(n_features - non_zero_vector, (-1, 1))
 
         X_transformed = np.hstack((non_zero, X_transformed))
         X_transformed = np.hstack((zero_col, X_transformed))

--- a/tpot/built_in_operators.py
+++ b/tpot/built_in_operators.py
@@ -20,11 +20,11 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import numpy as np
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import check_array
 
 
-class ZeroCount(BaseEstimator):
+class ZeroCount(BaseEstimator, TransformerMixin):
     """Adds the count of zeros and count of non-zeros per sample as features."""
 
     def fit(self, X, y=None):
@@ -52,19 +52,11 @@ class ZeroCount(BaseEstimator):
 
         X_transformed = np.copy(X)
 
-        non_zero = np.apply_along_axis(
-            lambda row: np.count_nonzero(row),
-            axis=1,
-            arr=X_transformed
-        )
-        zero_col = np.apply_along_axis(
-            lambda row: (n_features - np.count_nonzero(row)),
-            axis=1,
-            arr=X_transformed
-        )
+        non_zero = np.reshape(np.count_nonzero(X_transformed, axis=1), (-1,1))
+        zero_col = np.reshape(n_features - np.count_nonzero(X_transformed, axis=1), (-1,1))
 
-        X_transformed = np.insert(X_transformed, n_features, non_zero, axis=1)
-        X_transformed = np.insert(X_transformed, n_features + 1, zero_col, axis=1)
+        X_transformed = np.hstack((non_zero, X_transformed))
+        X_transformed = np.hstack((zero_col, X_transformed))
 
         return X_transformed
 


### PR DESCRIPTION
A small update for `ZeroCount` operator:

1. Remove `lambda` function in` ZeroCount` for pickling pipeline

2. Make `ZeroCount` as a subclass of TransformerMixin

3. Add a unit test for `ZeroCount`

Note: this PR should have conflicts with PR #460. Please let me know if #460 is merged then I will rebase this PR to dev branch again.