### PR TITLE
Minor improvements

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -842,7 +842,6 @@ class TPOTBase(BaseEstimator):
         unique_individuals = [ind for i, ind in enumerate(individuals) if i in unique_individual_indices]
 
         # return fitness scores
-        fitnesses_dict = {}
         operator_counts = {}
         # 4 lists of DEAP individuals, their sklearn pipelines and their operator counts for parallel computing
         eval_individuals_str = []

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -837,14 +837,18 @@ class TPOTBase(BaseEstimator):
             if total_mins_elapsed >= self.max_time_mins:
                 raise KeyboardInterrupt('{} minutes have elapsed. TPOT will close down.'.format(total_mins_elapsed))
 
+        # Check we do not evaluate twice the same individual in one pass.
+        _, unique_individual_indices = np.unique([str(ind) for ind in individuals], return_index=True)
+        unique_individuals = [ind for i, ind in enumerate(individuals) if i in unique_individual_indices]
+
         # return fitness scores
         fitnesses_dict = {}
+        operator_counts = {}
         # 4 lists of DEAP individuals, their sklearn pipelines and their operator counts for parallel computing
         eval_individuals_str = []
         sklearn_pipeline_list = []
-        operator_count_list = []
-        test_idx_list = []
-        for indidx, individual in enumerate(individuals):
+
+        for individual in unique_individuals:
             # Disallow certain combinations of operators because they will take too long or take up too much RAM
             # This is a fairly hacky way to prevent TPOT from getting stuck on bad pipelines and should be improved in a future release
             individual_str = str(individual)
@@ -852,13 +856,11 @@ class TPOTBase(BaseEstimator):
             if sklearn_pipeline_str.count('PolynomialFeatures') > 1:
                 if self.verbosity > 2:
                     self._pbar.write('Invalid pipeline encountered. Skipping its evaluation.')
-                fitnesses_dict[indidx] = (5000., -float('inf'))
+                self.evaluated_individuals_[individual_str] = (5000., -float('inf'))
                 if not self._pbar.disable:
                     self._pbar.update(1)
             # Check if the individual was evaluated before
             elif individual_str in self.evaluated_individuals_:
-                # Get fitness score from previous evaluation
-                fitnesses_dict[indidx] = self.evaluated_individuals_[individual_str]
                 if self.verbosity > 2:
                     self._pbar.write('Pipeline encountered that has previously been evaluated during the '
                                      'optimization process. Using the score from the previous evaluation.')
@@ -869,22 +871,19 @@ class TPOTBase(BaseEstimator):
                     # Transform the tree expression into an sklearn pipeline
                     sklearn_pipeline = self._toolbox.compile(expr=individual)
 
-
                     # Fix random state when the operator allows and build sample weight dictionary
                     self._set_param_recursive(sklearn_pipeline.steps, 'random_state', 42)
 
                     # Count the number of pipeline operators as a measure of pipeline complexity
                     operator_count = self._operator_count(individual)
-
+                    operator_counts[individual_str] = max(1, operator_count)
                 except Exception:
-                    fitnesses_dict[indidx] = (5000., -float('inf'))
+                    self.evaluated_individuals_[individual_str] = (5000., -float('inf'))
                     if not self._pbar.disable:
                         self._pbar.update(1)
                     continue
                 eval_individuals_str.append(individual_str)
-                operator_count_list.append(operator_count)
                 sklearn_pipeline_list.append(sklearn_pipeline)
-                test_idx_list.append(indidx)
 
         # evalurate pipeline
         resulting_score_list = []
@@ -918,17 +917,13 @@ class TPOTBase(BaseEstimator):
                 else:
                     resulting_score_list.append(val)
 
-        for resulting_score, operator_count, individual_str, test_idx in zip(resulting_score_list, operator_count_list, eval_individuals_str, test_idx_list):
+        for resulting_score, individual_str in zip(resulting_score_list, eval_individuals_str):
             if type(resulting_score) in [float, np.float64, np.float32]:
-                self.evaluated_individuals_[individual_str] = (max(1, operator_count), resulting_score)
-                fitnesses_dict[test_idx] = self.evaluated_individuals_[individual_str]
+                self.evaluated_individuals_[individual_str] = (operator_counts[individual_str], resulting_score)
             else:
                 raise ValueError('Scoring function does not return a float.')
 
-        fitnesses_ordered = []
-        for key in sorted(fitnesses_dict.keys()):
-            fitnesses_ordered.append(fitnesses_dict[key])
-        return fitnesses_ordered
+        return [self.evaluated_individuals_[str(individual)] for individual in individuals]
 
     @_pre_test
     def _mate_operator(self, ind1, ind2):

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -847,7 +847,6 @@ class TPOTBase(BaseEstimator):
         for indidx, individual in enumerate(individuals):
             # Disallow certain combinations of operators because they will take too long or take up too much RAM
             # This is a fairly hacky way to prevent TPOT from getting stuck on bad pipelines and should be improved in a future release
-            individual = individuals[indidx]
             individual_str = str(individual)
             sklearn_pipeline_str = generate_pipeline_code(expr_to_tree(individual, self._pset), self.operators)
             if sklearn_pipeline_str.count('PolynomialFeatures') > 1:


### PR DESCRIPTION
## What does this PR do?
Slightly refactored the TPOTBase._evaluate_individuals function changing:
 - Better legibility. After the introduction of parallelized evaluations of individuals, there was a lot of list-keeping added. This made the function very verbose and made it harder to see from a glance what happened. The rework requires zero list-indexing or sorting and has fewer lists, which hopefully makes it easier to read. Furthermore, some logic used to be delayed (eg. faulty pipelines would only be recorded in the evaluated_individuals_ dict way after they were found to be faulty, operator_count would first be calculated, but then quickly altered (max-operator) much later, just before being stored), these things are now more centralized.
- While it was checked if individuals had been evaluated before, if two identical new individuals would be asked to be evaluated, both would be (double work). Now, the list of all individuals is first reduced to a list of unique individuals before doing all the work, so no identical individual has to be evaluated twice.

## Where should the reviewer start?
All changes are confined to _evaluate_individuals.

## How should this PR be tested?
Just run a before and after version, it should behave exactly the same (minus a slight performance improvement due to no duplicate evaluations).
One of the tests explicitly verifies that the ordering of input and output is the same (and it passes).
**note**: One test fails for me, (assert that ZeroCount operator returns correct transformed X), but this **also** happens in the development branch. So as far as I can tell, no errors have been introduced.

## Any background context you want to provide?
These are some changes I have been using in my own branches for a while now, I figured I would add them here instead of waiting for an eventual Gradual TPOT integration.

## What are the relevant issues?
I did not submit a separate issue for this.
