### PR TITLE
Fixed division by zero error in metrics.py

### DIFF
--- a/tpot/metrics.py
+++ b/tpot/metrics.py
@@ -39,7 +39,7 @@ def balanced_accuracy(y_true, y_pred):
     Returns
     -------
     fitness: float
-        Returns a float value indicating the `individual`'s balanced accuracy
+        Returns a float value indicating the individual's balanced accuracy
         0.5 is as good as chance, and 1.0 is perfect predictive accuracy
     """
     all_classes = list(set(np.append(y_true, y_pred)))
@@ -47,11 +47,11 @@ def balanced_accuracy(y_true, y_pred):
     for this_class in all_classes:
         this_class_sensitivity = 0.
         this_class_specificity = 0.
-        if sum((y_true == this_class)) != 0:
+        if sum(y_true == this_class) != 0:
             this_class_sensitivity = \
                 float(sum((y_pred == this_class) & (y_true == this_class))) /\
                 float(sum((y_true == this_class)))
-        if sum((y_true != this_class)) != 0:
+
             this_class_specificity = \
                 float(sum((y_pred != this_class) & (y_true != this_class))) /\
                 float(sum((y_true != this_class)))

--- a/tpot/metrics.py
+++ b/tpot/metrics.py
@@ -45,10 +45,12 @@ def balanced_accuracy(y_true, y_pred):
     all_classes = list(set(np.append(y_true, y_pred)))
     all_class_accuracies = []
     for this_class in all_classes:
-        this_class_sensitivity = \
-            float(sum((y_pred == this_class) & (y_true == this_class))) /\
-            float(sum((y_true == this_class)))
-
+        if float(sum((y_true == this_class))) == 0:
+            this_class_sensitivity = 0
+        else:
+            this_class_sensitivity = \
+                float(sum((y_pred == this_class) & (y_true == this_class))) /\
+                float(sum((y_true == this_class)))
         this_class_specificity = \
             float(sum((y_pred != this_class) & (y_true != this_class))) /\
             float(sum((y_true != this_class)))

--- a/tpot/metrics.py
+++ b/tpot/metrics.py
@@ -45,15 +45,16 @@ def balanced_accuracy(y_true, y_pred):
     all_classes = list(set(np.append(y_true, y_pred)))
     all_class_accuracies = []
     for this_class in all_classes:
-        if float(sum((y_true == this_class))) == 0:
-            this_class_sensitivity = 0
-        else:
+        this_class_sensitivity = 0.
+        this_class_specificity = 0.
+        if sum((y_true == this_class)) != 0:
             this_class_sensitivity = \
                 float(sum((y_pred == this_class) & (y_true == this_class))) /\
                 float(sum((y_true == this_class)))
-        this_class_specificity = \
-            float(sum((y_pred != this_class) & (y_true != this_class))) /\
-            float(sum((y_true != this_class)))
+        if sum((y_true != this_class)) != 0:
+            this_class_specificity = \
+                float(sum((y_pred != this_class) & (y_true != this_class))) /\
+                float(sum((y_true != this_class)))
 
         this_class_accuracy = (this_class_sensitivity + this_class_specificity) / 2.
         all_class_accuracies.append(this_class_accuracy)


### PR DESCRIPTION
## What does this PR do?

Fixed division by zero error in metrics.py. Added one line of condition check.

## Where should the reviewer start?

[https://github.com/rhiever/tpot/blob/master/tpot/metrics.py#L50](url)

## How should this PR be tested?

This is a small test file that tests and compare the functionality and output of the new and old balanced_accuracy function
[test.py.zip](https://github.com/rhiever/tpot/files/1069169/test.py.zip)


## Any background context you want to provide?

The issue is found by @KhaledSharif and followed up discussion are in that thread.

## What are the relevant issues?

#493 

## Screenshots (if appropriate)

Result on [0, 1, 2, 3] and [0, 1, 2, 3]:
Original:
1.0
Fixed:
1.0
Result on [0, 1, 2, 3] and [1, 1, 2, 3]:
Original:
0.833333333333
Fixed:
0.833333333333
Result on [0, 1, 2, 3] and [1, 2, 3, 4]:
Original:
float division by zero
Fixed:
0.375

Ran 97 tests in 33.164s

OK

## Questions:

- Do the docs need to be updated?
No
- Does this PR add new (Python) dependencies?
No
- Note
This is my first time contributing to open source projects. I'd like this quick fix to be a practice. Please let me know if I did anything wrong. Thank you.
