### PR TITLE
Removing "DEFAULT" value in terminals

### DIFF
--- a/tests/export_tests.py
+++ b/tests/export_tests.py
@@ -335,7 +335,7 @@ def test_export_pipeline_5():
     tpot_obj = TPOTRegressor()
     pipeline_string = (
         'DecisionTreeRegressor(SelectFromModel(input_matrix, '
-        'SelectFromModel__ExtraTreesRegressor__max_features=DEFAULT, SelectFromModel__ExtraTreesRegressor__n_estimators=100, '
+        'SelectFromModel__ExtraTreesRegressor__max_features=0.05, SelectFromModel__ExtraTreesRegressor__n_estimators=100, '
         'SelectFromModel__threshold=0.05), DecisionTreeRegressor__max_depth=8,'
         'DecisionTreeRegressor__min_samples_leaf=5, DecisionTreeRegressor__min_samples_split=5)'
     )
@@ -355,7 +355,7 @@ training_features, testing_features, training_target, testing_target = \\
     train_test_split(features, tpot_data['class'], random_state=42)
 
 exported_pipeline = make_pipeline(
-    SelectFromModel(estimator=ExtraTreesRegressor(n_estimators=100), threshold=0.05),
+    SelectFromModel(estimator=ExtraTreesRegressor(max_features=0.05, n_estimators=100), threshold=0.05),
     DecisionTreeRegressor(max_depth=8, min_samples_leaf=5, min_samples_split=5)
 )
 

--- a/tests/export_tests.py
+++ b/tests/export_tests.py
@@ -22,7 +22,7 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 from tqdm import tqdm
 import numpy as np
 
-from tpot import TPOTClassifier
+from tpot import TPOTClassifier, TPOTRegressor
 from tpot.export_utils import export_pipeline, generate_import_code, _indent, generate_pipeline_code, get_by_name
 from tpot.operator_utils import TPOTOperatorClassFactory
 from tpot.config.classifier import classifier_config_dict
@@ -322,6 +322,41 @@ exported_pipeline = make_pipeline(
         FunctionTransformer(copy)
     ),
     KNeighborsClassifier(n_neighbors=10, p=1, weights="uniform")
+)
+
+exported_pipeline.fit(training_features, training_target)
+results = exported_pipeline.predict(testing_features)
+"""
+    assert expected_code == export_pipeline(pipeline, tpot_obj.operators, tpot_obj._pset)
+
+
+def test_export_pipeline_5():
+    """Assert that exported_pipeline() generated a compile source file as expected given a fixed simple pipeline with SelectFromModel."""
+    tpot_obj = TPOTRegressor()
+    pipeline_string = (
+        'DecisionTreeRegressor(SelectFromModel(input_matrix, '
+        'SelectFromModel__ExtraTreesRegressor__max_features=DEFAULT, SelectFromModel__ExtraTreesRegressor__n_estimators=100, '
+        'SelectFromModel__threshold=0.05), DecisionTreeRegressor__max_depth=8,'
+        'DecisionTreeRegressor__min_samples_leaf=5, DecisionTreeRegressor__min_samples_split=5)'
+    )
+    pipeline = creator.Individual.from_string(pipeline_string, tpot_obj._pset)
+    expected_code = """import numpy as np
+
+from sklearn.ensemble import ExtraTreesRegressor
+from sklearn.feature_selection import SelectFromModel
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import make_pipeline
+from sklearn.tree import DecisionTreeRegressor
+
+# NOTE: Make sure that the class is labeled 'class' in the data file
+tpot_data = np.recfromcsv('PATH/TO/DATA/FILE', delimiter='COLUMN_SEPARATOR', dtype=np.float64)
+features = np.delete(tpot_data.view(np.float64).reshape(tpot_data.size, -1), tpot_data.dtype.names.index('class'), axis=1)
+training_features, testing_features, training_target, testing_target = \\
+    train_test_split(features, tpot_data['class'], random_state=42)
+
+exported_pipeline = make_pipeline(
+    SelectFromModel(estimator=ExtraTreesRegressor(n_estimators=100), threshold=0.05),
+    DecisionTreeRegressor(max_depth=8, min_samples_leaf=5, min_samples_split=5)
 )
 
 exported_pipeline.fit(training_features, training_target)

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -712,7 +712,7 @@ def test_PolynomialFeatures_exception():
         'LogisticRegression(PolynomialFeatures'
         '(input_matrix, PolynomialFeatures__degree=2, PolynomialFeatures__include_bias=False, '
         'PolynomialFeatures__interaction_only=False), LogisticRegression__C=10.0, '
-        'LogisticRegression__dual=False, LogisticRegression__penalty=l1)'
+        'LogisticRegression__dual=False, LogisticRegression__penalty=l2)'
     )
 
     # pipeline with two PolynomialFeatures operator
@@ -722,7 +722,7 @@ def test_PolynomialFeatures_exception():
         'PolynomialFeatures__include_bias=False, PolynomialFeatures__interaction_only=False), '
         'PolynomialFeatures__degree=2, PolynomialFeatures__include_bias=False, '
         'PolynomialFeatures__interaction_only=False), LogisticRegression__C=10.0, '
-        'LogisticRegression__dual=False, LogisticRegression__penalty=l1)'
+        'LogisticRegression__dual=False, LogisticRegression__penalty=l2)'
     )
 
     # make a list for _evaluate_individuals

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -730,7 +730,6 @@ def test_PolynomialFeatures_exception():
     pipelines.append(creator.Individual.from_string(pipeline_string_1, tpot_obj._pset))
     pipelines.append(creator.Individual.from_string(pipeline_string_2, tpot_obj._pset))
     fitness_scores = tpot_obj._evaluate_individuals(pipelines, training_features, training_target)
-    print(fitness_scores)
     known_scores = [(2, 0.98068077235290885), (5000.0, -float('inf'))]
     assert np.allclose(known_scores, fitness_scores)
 

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -714,19 +714,19 @@ def test_PolynomialFeatures_exception():
     # pipeline with one PolynomialFeatures operator
     pipeline_string_1 = (
         'LogisticRegression(PolynomialFeatures'
-        '(input_matrix, PolynomialFeatures__degree=2, PolynomialFeatures__include_bias=DEFAULT, '
+        '(input_matrix, PolynomialFeatures__degree=2, PolynomialFeatures__include_bias=False, '
         'PolynomialFeatures__interaction_only=False), LogisticRegression__C=10.0, '
-        'LogisticRegression__dual=DEFAULT, LogisticRegression__penalty=DEFAULT)'
+        'LogisticRegression__dual=False, LogisticRegression__penalty=l1)'
     )
 
     # pipeline with two PolynomialFeatures operator
     pipeline_string_2 = (
         'LogisticRegression(PolynomialFeatures'
         '(PolynomialFeatures(input_matrix, PolynomialFeatures__degree=2, '
-        'PolynomialFeatures__include_bias=DEFAULT, PolynomialFeatures__interaction_only=False), '
-        'PolynomialFeatures__degree=2, PolynomialFeatures__include_bias=DEFAULT, '
+        'PolynomialFeatures__include_bias=False, PolynomialFeatures__interaction_only=False), '
+        'PolynomialFeatures__degree=2, PolynomialFeatures__include_bias=False, '
         'PolynomialFeatures__interaction_only=False), LogisticRegression__C=10.0, '
-        'LogisticRegression__dual=DEFAULT, LogisticRegression__penalty=DEFAULT)'
+        'LogisticRegression__dual=False, LogisticRegression__penalty=l1)'
     )
 
     # make a list for _evaluate_individuals
@@ -734,6 +734,7 @@ def test_PolynomialFeatures_exception():
     pipelines.append(creator.Individual.from_string(pipeline_string_1, tpot_obj._pset))
     pipelines.append(creator.Individual.from_string(pipeline_string_2, tpot_obj._pset))
     fitness_scores = tpot_obj._evaluate_individuals(pipelines, training_features, training_target)
+    print(fitness_scores)
     known_scores = [(2, 0.98068077235290885), (5000.0, -float('inf'))]
     assert np.allclose(known_scores, fitness_scores)
 

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -399,9 +399,6 @@ class TPOTBase(BaseEstimator):
     def _add_terminals(self):
         for _type in self.arguments:
             type_values = list(_type.values)
-            # This check prevents XGBoost from using multithreading, which breaks in TPOT
-            if 'nthread' not in _type.__name__:
-                type_values += ['DEFAULT']
 
             for val in type_values:
                 terminal_name = _type.__name__ + "=" + str(val)

--- a/tpot/operator_utils.py
+++ b/tpot/operator_utils.py
@@ -230,7 +230,7 @@ def TPOTOperatorClassFactory(opsourse, opdict, BaseClass=Operator, ArgBaseClass=
                 if isinstance(arg_value, str):
                     arg_value = '\"{}\"'.format(arg_value)
                 if len(aname_split) == 2:  # simple parameter
-                    if arg_value != "DEFAULT":
+                    if arg_value != '\"DEFAULT\"':
                         op_arguments.append("{}={}".format(aname_split[-1], arg_value))
                 # Parameter of internal operator as a parameter in the
                 # operator, usually in Selector
@@ -240,7 +240,7 @@ def TPOTOperatorClassFactory(opsourse, opdict, BaseClass=Operator, ArgBaseClass=
                     else:
                         if aname_split[1] not in dep_op_arguments:
                             dep_op_arguments[aname_split[1]] = []
-                        if arg_value != "DEFAULT":
+                        if arg_value != '\"DEFAULT\"':
                             dep_op_arguments[aname_split[1]].append("{}={}".format(aname_split[-1], arg_value))
 
             tmp_op_args = []

--- a/tpot/operator_utils.py
+++ b/tpot/operator_utils.py
@@ -226,13 +226,12 @@ def TPOTOperatorClassFactory(opsourse, opdict, BaseClass=Operator, ArgBaseClass=
                 dep_op_arguments = {}
 
             for arg_class, arg_value in zip(arg_types, args):
-                if arg_value == "DEFAULT":
-                    continue
                 aname_split = arg_class.__name__.split('__')
                 if isinstance(arg_value, str):
                     arg_value = '\"{}\"'.format(arg_value)
                 if len(aname_split) == 2:  # simple parameter
-                    op_arguments.append("{}={}".format(aname_split[-1], arg_value))
+                    if arg_value != "DEFAULT":
+                        op_arguments.append("{}={}".format(aname_split[-1], arg_value))
                 # Parameter of internal operator as a parameter in the
                 # operator, usually in Selector
                 else:
@@ -241,7 +240,8 @@ def TPOTOperatorClassFactory(opsourse, opdict, BaseClass=Operator, ArgBaseClass=
                     else:
                         if aname_split[1] not in dep_op_arguments:
                             dep_op_arguments[aname_split[1]] = []
-                        dep_op_arguments[aname_split[1]].append("{}={}".format(aname_split[-1], arg_value))
+                        if arg_value != "DEFAULT":
+                            dep_op_arguments[aname_split[1]].append("{}={}".format(aname_split[-1], arg_value))
 
             tmp_op_args = []
             if dep_op_list:

--- a/tpot/operator_utils.py
+++ b/tpot/operator_utils.py
@@ -230,8 +230,7 @@ def TPOTOperatorClassFactory(opsourse, opdict, BaseClass=Operator, ArgBaseClass=
                 if isinstance(arg_value, str):
                     arg_value = '\"{}\"'.format(arg_value)
                 if len(aname_split) == 2:  # simple parameter
-                    if arg_value != '\"DEFAULT\"':
-                        op_arguments.append("{}={}".format(aname_split[-1], arg_value))
+                    op_arguments.append("{}={}".format(aname_split[-1], arg_value))
                 # Parameter of internal operator as a parameter in the
                 # operator, usually in Selector
                 else:
@@ -240,8 +239,7 @@ def TPOTOperatorClassFactory(opsourse, opdict, BaseClass=Operator, ArgBaseClass=
                     else:
                         if aname_split[1] not in dep_op_arguments:
                             dep_op_arguments[aname_split[1]] = []
-                        if arg_value != '\"DEFAULT\"':
-                            dep_op_arguments[aname_split[1]].append("{}={}".format(aname_split[-1], arg_value))
+                        dep_op_arguments[aname_split[1]].append("{}={}".format(aname_split[-1], arg_value))
 
             tmp_op_args = []
             if dep_op_list:


### PR DESCRIPTION
1. Fix a bug that "DEFAULT" in the parameter(s) of nested estimator causes `KeyError` when exporting pipeline, which is related to the issue #499 

2. Add a unit test for this issue

The [2 lines in `operator_utils.py`](https://github.com/rhiever/tpot/blob/v0.8/tpot/operator_utils.py#L229-L230) cause the bug in the issue #499. It works all right with operators without nested/stacked estimator as parameter(s) but it will cause `KeyError` once `dep_op_arguments` do not have nested/stacked estimator's name as key of the dictionary. It means that if any parameter is `DEFAULT` in the nested/stacked estimator would cause the whole pipeline cannot exported as valid scikit-learn Pipeline object.


