### PR TITLE
Fix self.set_param_recursive for nested estimators

### DIFF
--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -598,6 +598,60 @@ def test_update_top_pipeline_2():
     assert_raises(RuntimeError, tpot_obj._update_top_pipeline, features=training_features, target=training_target)
 
 
+def test_set_param_recursive():
+    """Assert that _set_param_recursive sets \"random_state\" to 42 in all steps in a simple pipeline"""
+    pipeline_string = (
+        'DecisionTreeClassifier(PCA(input_matrix, PCA__iterated_power=5, PCA__svd_solver=randomized), '
+        'DecisionTreeClassifier__criterion=gini, DecisionTreeClassifier__max_depth=8, '
+        'DecisionTreeClassifier__min_samples_leaf=5, DecisionTreeClassifier__min_samples_split=5)'
+    )
+    tpot_obj = TPOTClassifier()
+    deap_pipeline = creator.Individual.from_string(pipeline_string, tpot_obj._pset)
+    sklearn_pipeline = tpot_obj._toolbox.compile(expr=deap_pipeline)
+    tpot_obj._set_param_recursive(sklearn_pipeline.steps, 'random_state', 42)
+    # assert "random_state" of PCA at step 1
+    assert getattr(sklearn_pipeline.steps[0][1], 'random_state') == 42
+    # assert "random_state" of DecisionTreeClassifier at step 2
+    assert getattr(sklearn_pipeline.steps[1][1], 'random_state') == 42
+
+
+def test_set_param_recursive_2():
+    """Assert that _set_param_recursive sets \"random_state\" to 42 in nested estimator in SelectFromModel."""
+    pipeline_string = (
+        'DecisionTreeRegressor(SelectFromModel(input_matrix, '
+        'SelectFromModel__ExtraTreesRegressor__max_features=0.05, SelectFromModel__ExtraTreesRegressor__n_estimators=100, '
+        'SelectFromModel__threshold=0.05), DecisionTreeRegressor__max_depth=8,'
+        'DecisionTreeRegressor__min_samples_leaf=5, DecisionTreeRegressor__min_samples_split=5)'
+    )
+    tpot_obj = TPOTRegressor()
+    deap_pipeline = creator.Individual.from_string(pipeline_string, tpot_obj._pset)
+    sklearn_pipeline = tpot_obj._toolbox.compile(expr=deap_pipeline)
+    tpot_obj._set_param_recursive(sklearn_pipeline.steps, 'random_state', 42)
+
+    assert getattr(getattr(sklearn_pipeline.steps[0][1], 'estimator'), 'random_state') == 42
+    assert getattr(sklearn_pipeline.steps[1][1], 'random_state') == 42
+
+
+def test_set_param_recursive_3():
+    """Assert that _set_param_recursive sets \"random_state\" to 42 in nested estimator in StackingEstimator in a complex pipeline"""
+    pipeline_string = (
+        'DecisionTreeClassifier(CombineDFs('
+        'DecisionTreeClassifier(input_matrix, DecisionTreeClassifier__criterion=gini, '
+        'DecisionTreeClassifier__max_depth=8, DecisionTreeClassifier__min_samples_leaf=5,'
+        'DecisionTreeClassifier__min_samples_split=5),input_matrix) '
+        'DecisionTreeClassifier__criterion=gini, DecisionTreeClassifier__max_depth=8, '
+        'DecisionTreeClassifier__min_samples_leaf=5, DecisionTreeClassifier__min_samples_split=5)'
+    )
+    tpot_obj = TPOTClassifier()
+    deap_pipeline = creator.Individual.from_string(pipeline_string, tpot_obj._pset)
+    sklearn_pipeline = tpot_obj._toolbox.compile(expr=deap_pipeline)
+    tpot_obj._set_param_recursive(sklearn_pipeline.steps, 'random_state', 42)
+
+    # StackingEstimator under the transformer_list of FeatureUnion
+    assert getattr(getattr(sklearn_pipeline.steps[0][1].transformer_list[0][1], 'estimator'), 'random_state') == 42
+    assert getattr(sklearn_pipeline.steps[1][1], 'random_state') == 42
+
+
 def test_evaluated_individuals_():
     """Assert that evaluated_individuals_ stores current pipelines and their CV scores."""
     tpot_obj = TPOTClassifier(

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -599,7 +599,7 @@ def test_update_top_pipeline_2():
 
 
 def test_set_param_recursive():
-    """Assert that _set_param_recursive sets \"random_state\" to 42 in all steps in a simple pipeline"""
+    """Assert that _set_param_recursive sets \"random_state\" to 42 in all steps in a simple pipeline."""
     pipeline_string = (
         'DecisionTreeClassifier(PCA(input_matrix, PCA__iterated_power=5, PCA__svd_solver=randomized), '
         'DecisionTreeClassifier__criterion=gini, DecisionTreeClassifier__max_depth=8, '
@@ -633,7 +633,7 @@ def test_set_param_recursive_2():
 
 
 def test_set_param_recursive_3():
-    """Assert that _set_param_recursive sets \"random_state\" to 42 in nested estimator in StackingEstimator in a complex pipeline"""
+    """Assert that _set_param_recursive sets \"random_state\" to 42 in nested estimator in StackingEstimator in a complex pipeline."""
     pipeline_string = (
         'DecisionTreeClassifier(CombineDFs('
         'DecisionTreeClassifier(input_matrix, DecisionTreeClassifier__criterion=gini, '

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -863,6 +863,7 @@ class TPOTBase(BaseEstimator):
         sklearn_pipeline = generate_pipeline_code(expr_to_tree(expr, self._pset), self.operators)
         return eval(sklearn_pipeline, self.operators_context)
 
+
     def _set_param_recursive(self, pipeline_steps, parameter, value):
         """Recursively iterate through all objects in the pipeline and set a given parameter.
 
@@ -881,14 +882,16 @@ class TPOTBase(BaseEstimator):
         """
         for (_, obj) in pipeline_steps:
             recursive_attrs = ['steps', 'transformer_list', 'estimators']
-
             for attr in recursive_attrs:
                 if hasattr(obj, attr):
                     self._set_param_recursive(getattr(obj, attr), parameter, value)
-                    break
-            else:
-                if hasattr(obj, parameter):
-                    setattr(obj, parameter, value)
+            if hasattr(obj, 'estimator'): # nested estimator
+                est = getattr(obj, 'estimator')
+                if hasattr(est, parameter):
+                    setattr(est, parameter, value)
+            if hasattr(obj, parameter):
+                setattr(obj, parameter, value)
+
 
     def _evaluate_individuals(self, individuals, features, target, sample_weight=None, groups=None):
         """Determine the fit of the provided individuals.


### PR DESCRIPTION
## What does this PR do?

1. Fix a bug in `self.set_param_recursive ` for setting "random_state" in nested estimator. The issue would happen with pipeline with `SelectFromModel` (`ExtraTreesClassifier` as nested estimator) or `StackingEstimator` if nested estimator has "random_state" as a parameter.

2. Add 3 unit tests for this `self.set_param_recursive` function.

## Where should the reviewer start?

[L867 in base.py](https://github.com/weixuanfu2016/tpot/blob/8f4572c3535254b6a0e5fc231aa6c8ae627850b1/tpot/base.py#L867)

## How should this PR be tested?

Any TPOT example

## Questions:

- Do the docs need to be updated? No
- Does this PR add new (Python) dependencies? No
