### PR TITLE
Use Multiprocessing.Process and Pipe for timeout function

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn nose cython py-xgboost
   - activate test-environment
-  - pip install deap tqdm update_checker pypiwin32 stopit
+  - pip install deap tqdm update_checker pypiwin32
 
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn nose cython py-xgboost
   - activate test-environment
-  - pip install deap tqdm update_checker pypiwin32
+  - pip install deap tqdm update_checker
 
 
 test_script:

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -52,7 +52,6 @@ fi
 
 pip install update_checker
 pip install tqdm
-pip install stopit
 
 if [[ "$COVERAGE" == "true" ]]; then
     pip install coverage coveralls

--- a/docs_sources/installing.md
+++ b/docs_sources/installing.md
@@ -27,12 +27,6 @@ DEAP, update_checker and tqdm can be installed with `pip` via the command:
 pip install deap update_checker tqdm
 ```
 
-**For the Windows users**, the pywin32 module is required if Python is NOT installed via the [Anaconda Python distribution](https://www.continuum.io/downloads) and can be installed with `pip`:
-
-```Shell
-pip install pywin32
-```
-
 **Optionally**, you can install [XGBoost](https://github.com/dmlc/xgboost) if you would like TPOT to use the eXtreme Gradient Boosting models. XGBoost is entirely optional, and TPOT will still function normally without XGBoost if you do not have it installed.
 
 ```Shell

--- a/docs_sources/installing.md
+++ b/docs_sources/installing.md
@@ -21,10 +21,10 @@ NumPy, SciPy, and scikit-learn can be installed in Anaconda via the command:
 conda install numpy scipy scikit-learn
 ```
 
-DEAP, update_checker, tqdm and stopit can be installed with `pip` via the command:
+DEAP, update_checker and tqdm can be installed with `pip` via the command:
 
 ```Shell
-pip install deap update_checker tqdm stopit
+pip install deap update_checker tqdm
 ```
 
 **For the Windows users**, the pywin32 module is required if Python is NOT installed via the [Anaconda Python distribution](https://www.continuum.io/downloads) and can be installed with `pip`:

--- a/tests/driver_tests.py
+++ b/tests/driver_tests.py
@@ -48,7 +48,7 @@ def test_scoring_function_argument():
     with captured_output() as (out, err):
         # regular argument returns regular string
         assert_equal(load_scoring_function("roc_auc"), "roc_auc")
-        
+
         # bad function returns exception
         assert_raises(Exception, load_scoring_function, scoring_func="tests.__fake_BAD_FUNC_NAME")
 
@@ -68,16 +68,16 @@ def test_scoring_function_argument():
     assert_equal(err, "")
 
 
-
 def test_driver():
     """Assert that the TPOT driver outputs normal result in mode mode."""
-    batcmd = "python -m tpot.driver tests/tests.csv -is , -target class -g 2 -p 2 -os 4 -cv 5 -s 45 -v 1"
-    ret_stdout = subprocess.check_output(batcmd, shell=True)
-    try:
-        ret_val = float(ret_stdout.decode('UTF-8').split('\n')[-2].split(': ')[-1])
-    except Exception:
-        ret_val = -float('inf')
-    assert ret_val > 0.0
+    if not sys.platform.startswith('win') or sys.version_info.major != 2: # this test will fail in python 2.7 in Windows
+        batcmd = "python -m tpot.driver tests/tests.csv -is , -target class -g 2 -p 2 -os 4 -cv 5 -s 45 -v 1"
+        ret_stdout = subprocess.check_output(batcmd, shell=True)
+        try:
+            ret_val = float(ret_stdout.decode('UTF-8').split('\n')[-2].split(': ')[-1])
+        except Exception:
+            ret_val = -float('inf')
+        assert ret_val > 0.0
 
 
 def test_read_data_file():

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -991,7 +991,7 @@ class TPOTBase(BaseEstimator):
         else:
             # chunk size for pbar update
             for chunk_idx in range(0, len(sklearn_pipeline_list), self.n_jobs * 4):
-                parallel = Parallel(n_jobs=self.n_jobs, verbose=0, pre_dispatch='2*n_jobs')
+                parallel = Parallel(n_jobs=self.n_jobs, verbose=0, pre_dispatch='2*n_jobs', backend="threading")
                 tmp_result_scores = parallel(delayed(partial_wrapped_cross_val_score)(sklearn_pipeline=sklearn_pipeline)
                                              for sklearn_pipeline in sklearn_pipeline_list[chunk_idx:chunk_idx + self.n_jobs * 4])
                 # update pbar

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -63,22 +63,6 @@ from .metrics import SCORERS
 from .gp_types import Output_Array
 from .gp_deap import eaMuPlusLambda, mutNodeReplacement, _wrapped_cross_val_score, cxOnePoint
 
-# hot patch for Windows: solve the problem of crashing python after Ctrl + C in Windows OS
-if sys.platform.startswith('win'):
-    import win32api
-    try:
-        import _thread
-    except ImportError:
-        import thread as _thread
-
-    def handler(dwCtrlType, hook_sigint=_thread.interrupt_main):
-        """SIGINT handler function."""
-        if dwCtrlType == 0:  # CTRL_C_EVENT
-            hook_sigint()
-            return 1  # don't chain to the next handler
-        return 0
-    win32api.SetConsoleCtrlHandler(handler, 1)
-
 
 class TPOTBase(BaseEstimator):
     """Automatically creates and optimizes machine learning pipelines using GP."""
@@ -457,6 +441,17 @@ class TPOTBase(BaseEstimator):
             Returns a copy of the fitted TPOT object
 
         """
+
+        # If the OS is windows, ci
+        if sys.platform.startswith('win'):
+            print(
+                'Warning: Pressing Ctrl+C will freeze the optimization '
+                'process without saving the best pipeline in Windows! Thus, Please DO NOT '
+                'press Ctrl+C during the optimization procss For quick test in Windows, '
+                'please set max_eval_time_mins to decrease time limit (default: 5 minutes)'
+                'of evaluating a pipeline.'
+            )
+
         features = features.astype(np.float64)
 
         # Resets the imputer to be fit for the new dataset

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -448,7 +448,7 @@ class TPOTBase(BaseEstimator):
                 'Warning: Pressing Ctrl+C will freeze the optimization '
                 'process without saving the best pipeline in Windows! Thus, Please DO NOT '
                 'press Ctrl+C during the optimization procss For quick test in Windows, '
-                'please set max_eval_time_mins to decrease time limit (default: 5 minutes)'
+                'please set max_eval_time_mins to decrease time limit (default: 5 minutes) '
                 'of evaluating a pipeline.'
             )
 

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -36,7 +36,7 @@ from sklearn.model_selection._split import check_cv
 from sklearn.base import clone, is_classifier
 from collections import defaultdict
 import warnings
-from stopit import threading_timeoutable, TimeoutException
+from multiprocessing import Process, Pipe
 
 # Limit loops to generate a different individual by crossover/mutation
 MAX_MUT_LOOPS = 50
@@ -331,10 +331,57 @@ def mutNodeReplacement(individual, pset):
             individual[slice_] = new_subtree
     return individual,
 
+def _fit_score(sklearn_pipeline, features, target, cv_iter, cv, scorer, _conn, sample_weight_dict=None):
+    """
+    Fit estimator and compute scores for a given dataset split.
+    Parameters
+    ----------
+    sklearn_pipeline : pipeline object implementing 'fit'
+        The object to use to fit the data.
+    features : array-like of shape at least 2D
+        The data to fit.
+    target : array-like, optional, default: None
+        The target variable to try to predict in the case of
+        supervised learning.
+    cv_iter : list
+        Train and test datasets. Store it as list as we will be iterating
+        over the list multiple times
+    cv: int or cross-validation generator
+        If CV is a number, then it is the number of folds to evaluate each
+        pipeline over in k-fold cross-validation during the TPOT optimization
+         process. If it is an object then it is an object to be used as a
+         cross-validation generator.
+    scorer : callable
+        A scorer callable object / function with signature
+        ``scorer(estimator, X, y)``.
+    _conn : multiprocessing.Pipe object
+        Calling process
+    sample_weight_dict : dictionary, optional
+        dictionary of sample weights to balance (or un-balanace) the dataset target as neede
+    """
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            scores = [_fit_and_score(estimator=clone(sklearn_pipeline),
+                                    X=features,
+                                    y=target,
+                                    scorer=scorer,
+                                    train=train,
+                                    test=test,
+                                    verbose=0,
+                                    parameters=None,
+                                    fit_params=sample_weight_dict)
+                                for train, test in cv_iter]
+            CV_score = np.array(scores)[:, 0]
+            rval = np.mean(CV_score)
+    except Exception as e:
+        rval = -float('inf')
 
-@threading_timeoutable(default="Timeout")
+    # return the result to calling process
+    _conn.send(rval)
+
 def _wrapped_cross_val_score(sklearn_pipeline, features, target,
-                             cv, scoring_function, sample_weight=None, groups=None):
+                             cv, scoring_function, sample_weight=None, groups=None, timeout=300):
     """Fit estimator and compute scores for a given dataset split.
     Parameters
     ----------
@@ -357,7 +404,15 @@ def _wrapped_cross_val_score(sklearn_pipeline, features, target,
         List of sample weights to balance (or un-balanace) the dataset target as needed
     groups: array-like {n_samples, }, optional
         Group labels for the samples used while splitting the dataset into train/test set
+    timeout: int, optional
+        Time limits (seconds) of evalurating a pipeline
+
+    Returns
+    ----------
+    fn_rval[1]: str or float
+        Average CV score
     """
+
     sample_weight_dict = set_sample_weight(sklearn_pipeline.steps, sample_weight)
 
     features, target, groups = indexable(features, target, groups)
@@ -366,22 +421,22 @@ def _wrapped_cross_val_score(sklearn_pipeline, features, target,
     cv_iter = list(cv.split(features, target, groups))
     scorer = check_scoring(sklearn_pipeline, scoring=scoring_function)
 
-    try:
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            scores = [_fit_and_score(estimator=clone(sklearn_pipeline),
-                                    X=features,
-                                    y=target,
-                                    scorer=scorer,
-                                    train=train,
-                                    test=test,
-                                    verbose=0,
-                                    parameters=None,
-                                    fit_params=sample_weight_dict)
-                                for train, test in cv_iter]
-            CV_score = np.array(scores)[:, 0]
-            return np.mean(CV_score)
-    except TimeoutException:
-        return "Timeout"
-    except Exception as e:
-        return -float('inf')
+    conn1, conn2 = Pipe()
+    th = Process(target=_fit_score, args=(sklearn_pipeline,
+                                            features,
+                                            target,
+                                            cv_iter,
+                                            cv,
+                                            scorer,
+                                            conn2,
+                                            sample_weight_dict))
+    th.start()
+    if conn1.poll(timeout):
+        fn_rval = conn1.recv()
+        th.join()
+    else:
+        th.terminate()
+        th.join()
+        fn_rval = 'Timeout'
+
+    return fn_rval


### PR DESCRIPTION
## What does this PR do?

1. Use `Process` and `Pipe` instead of `Threading` for timeout function since Thread cannot be killed #508 

2. Use `threading` backend in joblib since daemonic processes with `multiprocessing` backend are not allowed to have children process

3. Add a warning message about CTRL+C for Windows user

4. update doc for removing dependencies of `stopit` and `pywin32` module 
## Where should the reviewer start?

gp_deap.py

## How should this PR be tested?

```
# coding: utf-8
from sklearn.datasets import make_classification
from tpot import TPOTClassifier
# make a huge dataset
X, y = make_classification(n_samples=50000, n_features=200,
                                    n_informative=20, n_redundant=20,
                                    n_classes=5, random_state=42)

# max_eval_time_mins=0.04 means 2 seconds limits for evaluating a single pipeline 
# working in both Windows and Linux OS
tpot = TPOTClassifier(generations=5, population_size=50, offspring_size=100, random_state=42, n_jobs=1, max_eval_time_mins=0.04, verbosity=3) 
tpot.fit(X, y)
```


## What are the relevant issues?

#508 
#436 

## Screenshots (if appropriate)



## Questions:

- Do the docs need to be updated? Yes, updated
- Does this PR add new (Python) dependencies? No
