### PR TITLE
Moved GP to nanmean

### DIFF
--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -370,7 +370,7 @@ def _wrapped_cross_val_score(sklearn_pipeline, features, target,
     if tmp_it.isAlive():
         resulting_score = 'Timeout'
     else:
-        resulting_score = np.mean(tmp_it.result)
+        resulting_score = np.nanmean(tmp_it.result)
 
     tmp_it.stop()
     return resulting_score


### PR DESCRIPTION
moving to nanmean allows custom scorers that may return nan in certain situtations.

[please review the [contribution guidelines](http://rhiever.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]

## What does this PR do?
Solves a problem when scorers may return nan instead of a float


## Where should the reviewer start?

gp_deap.py 


## How should this PR be tested?



## Any background context you want to provide?



## What are the relevant issues?

[you can link directly to issues by entering # then the number of the issue, for example, #3 links to issue 3]

## Screenshots (if appropriate)



## Questions:

- Do the docs need to be updated?
- Does this PR add new (Python) dependencies?
