### PR TITLE
Refine_evaluate_individuals and more unit tests

### DIFF
--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -668,7 +668,7 @@ def test_fit_3():
 
 
 def test_fit_4():
-    """Assert that the TPOT fit function provides an optimized pipeline with max_time_mins of 1 seconds"""
+    """Assert that the TPOT fit function provides an optimized pipeline with max_time_mins of 1 second."""
     tpot_obj = TPOTClassifier(
         random_state=42,
         population_size=5,

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -1102,9 +1102,12 @@ def test_preprocess_individuals_2():
         verbosity=0
     )
 
+    # pipeline with two PolynomialFeatures operator
     pipeline_string_1 = (
         'LogisticRegression(PolynomialFeatures'
-        '(input_matrix, PolynomialFeatures__degree=2, PolynomialFeatures__include_bias=False, '
+        '(PolynomialFeatures(input_matrix, PolynomialFeatures__degree=2, '
+        'PolynomialFeatures__include_bias=False, PolynomialFeatures__interaction_only=False), '
+        'PolynomialFeatures__degree=2, PolynomialFeatures__include_bias=False, '
         'PolynomialFeatures__interaction_only=False), LogisticRegression__C=10.0, '
         'LogisticRegression__dual=False, LogisticRegression__penalty=l2)'
     )
@@ -1131,6 +1134,7 @@ def test_preprocess_individuals_2():
         operator_counts, eval_individuals_str, sklearn_pipeline_list = \
                                 tpot_obj._preprocess_individuals(individuals)
         our_file.seek(0)
+
         assert_in("Invalid pipeline encountered. Skipping its evaluation.", our_file.read())
         assert_in(pipeline_string_2, eval_individuals_str)
         assert_equal(operator_counts[pipeline_string_2], 1)
@@ -1147,12 +1151,9 @@ def test_preprocess_individuals_3():
         verbosity=0
     )
 
-    # pipeline with two PolynomialFeatures operator
     pipeline_string_1 = (
         'LogisticRegression(PolynomialFeatures'
-        '(PolynomialFeatures(input_matrix, PolynomialFeatures__degree=2, '
-        'PolynomialFeatures__include_bias=False, PolynomialFeatures__interaction_only=False), '
-        'PolynomialFeatures__degree=2, PolynomialFeatures__include_bias=False, '
+        '(input_matrix, PolynomialFeatures__degree=2, PolynomialFeatures__include_bias=False, '
         'PolynomialFeatures__interaction_only=False), LogisticRegression__C=10.0, '
         'LogisticRegression__dual=False, LogisticRegression__penalty=l2)'
     )
@@ -1516,7 +1517,6 @@ def test_varOr_2():
     pop = tpot_obj._toolbox.population(n=5)
     for ind in pop:
         ind.fitness.values = (2, 1.0)
-        print(type(ind.fitness.values))
 
     offspring = varOr(pop, tpot_obj._toolbox, 5, cxpb=0.0, mutpb=1.0)
     invalid_ind = [ind for ind in offspring if not ind.fitness.valid]

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -683,9 +683,7 @@ def test_fit_4():
     tpot_obj.generations == 100
 
     tpot_obj.fit(training_features, training_target)
-    total_mins_elapsed = (datetime.now() - tpot_obj._start_datetime).total_seconds() / 60.
-    # allow two seconds more
-    assert total_mins_elapsed < 4/60.
+    
     assert isinstance(tpot_obj._optimized_pipeline, creator.Individual)
     assert not (tpot_obj._start_datetime is None)
 

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -1113,6 +1113,7 @@ def test_preprocess_individuals_2():
         assert_equal(operator_counts[pipeline_string_2], 1)
         assert_equal(len(sklearn_pipeline_list), 1)
 
+
 def test_preprocess_individuals_3():
     """Assert _preprocess_individuals updatas self._pbar.total when max_time_mins is not None"""
     tpot_obj = TPOTClassifier(
@@ -1156,8 +1157,6 @@ def test_preprocess_individuals_3():
         operator_counts, eval_individuals_str, sklearn_pipeline_list = \
                                 tpot_obj._preprocess_individuals(individuals)
         assert tpot_obj._pbar.total == 6
-
-
 
 
 def test_imputer():

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -1379,33 +1379,6 @@ def test_cxOnePoint():
     assert offspring2[0].ret == Output_Array
 
 
-def test_cxOnePoint_2():
-    """Assert that cxOnePoint() return the same individuals if one of individuals only has one operators"""
-    tpot_obj = TPOTClassifier()
-    ind1 = creator.Individual.from_string(
-        'KNeighborsClassifier(input_matrix '
-        'KNeighborsClassifier__n_neighbors=10, '
-        'KNeighborsClassifier__p=1, '
-        'KNeighborsClassifier__weights=uniform'
-        ')',
-        tpot_obj._pset
-    )
-    ind2 = creator.Individual.from_string(
-        'KNeighborsClassifier('
-        'BernoulliNB(input_matrix, BernoulliNB__alpha=10.0, BernoulliNB__fit_prior=True),'
-        'KNeighborsClassifier__n_neighbors=10, '
-        'KNeighborsClassifier__p=2, '
-        'KNeighborsClassifier__weights=uniform'
-        ')',
-        tpot_obj._pset
-    )
-
-    offspring1, offspring2 = cxOnePoint(ind1, ind2)
-
-    assert offspring1 == ind1
-    assert offspring2 == ind2
-
-
 def test_mutNodeReplacement():
     """Assert that mutNodeReplacement() returns the correct type of mutation node in a fixed pipeline."""
     tpot_obj = TPOTClassifier()

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -915,6 +915,15 @@ def test_evaluated_individuals_():
         assert np.allclose(tpot_obj.evaluated_individuals_[pipeline_string][0], operator_count)
 
 
+def test_stop_by_max_time_mins():
+    """Assert that _stop_by_max_time_mins raises KeyboardInterrupt when maximum minutes have elapsed."""
+    tpot_obj = TPOTClassifier(config_dict='TPOT light')
+    tpot_obj._start_datetime = datetime.now()
+    sleep(0.1)
+    tpot_obj.max_time_mins = 0.1/60.
+    assert_raises(KeyboardInterrupt, tpot_obj._stop_by_max_time_mins)
+
+
 def test_evaluate_individuals():
     """Assert that _evaluate_individuals returns operator_counts and CV scores in correct order."""
     tpot_obj = TPOTClassifier(

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -679,11 +679,11 @@ def test_fit_4():
     )
     assert tpot_obj.generations == 1000000
 
-    # reset generations to 10 just in case that the failed test may take too much time
-    tpot_obj.generations == 100
+    # reset generations to 20 just in case that the failed test may take too much time
+    tpot_obj.generations == 20
 
     tpot_obj.fit(training_features, training_target)
-    
+
     assert isinstance(tpot_obj._optimized_pipeline, creator.Individual)
     assert not (tpot_obj._start_datetime is None)
 

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -668,13 +668,13 @@ def test_fit_3():
 
 
 def test_fit_4():
-    """Assert that the TPOT fit function provides an optimized pipeline with max_time_mins of 1 second."""
+    """Assert that the TPOT fit function provides an optimized pipeline with max_time_mins of 2 second."""
     tpot_obj = TPOTClassifier(
         random_state=42,
-        population_size=5,
+        population_size=2,
         generations=1,
         verbosity=0,
-        max_time_mins=1/60.,
+        max_time_mins=2/60.,
         config_dict='TPOT light'
     )
     assert tpot_obj.generations == 1000000
@@ -685,7 +685,7 @@ def test_fit_4():
     tpot_obj.fit(training_features, training_target)
     total_mins_elapsed = (datetime.now() - tpot_obj._start_datetime).total_seconds() / 60.
     # allow two seconds more
-    assert total_mins_elapsed < 3/60.
+    assert total_mins_elapsed < 4/60.
     assert isinstance(tpot_obj._optimized_pipeline, creator.Individual)
     assert not (tpot_obj._start_datetime is None)
 
@@ -705,7 +705,7 @@ def test_save_pipeline_if_period():
         tpot_obj._file = our_file
         tpot_obj.verbosity = 3
         tpot_obj._last_pipeline_write = datetime.now()
-        sleep(0.1)
+        sleep(0.11)
         tpot_obj._output_best_pipeline_period_seconds = 0.1
         tpot_obj.periodic_checkpoint_folder = './'
         tpot_obj._save_pipeline_if_period(training_features, training_target)
@@ -733,7 +733,7 @@ def test_save_pipeline_if_period_2():
         tpot_obj._file = our_file
         tpot_obj.verbosity = 3
         tpot_obj._last_pipeline_write = datetime.now()
-        sleep(0.1)
+        sleep(0.11)
         tpot_obj._output_best_pipeline_period_seconds = 0.1
         tpot_obj.periodic_checkpoint_folder = './'
         # export once before
@@ -763,7 +763,7 @@ def test_save_pipeline_if_period_3():
         tpot_obj._file = our_file
         tpot_obj.verbosity = 3
         tpot_obj._last_pipeline_write = datetime.now()
-        sleep(0.1)
+        sleep(0.11)
         tpot_obj._output_best_pipeline_period_seconds = 0.1
         tpot_obj.periodic_checkpoint_folder = './'
         # reset _optimized_pipeline
@@ -942,7 +942,7 @@ def test_stop_by_max_time_mins():
     """Assert that _stop_by_max_time_mins raises KeyboardInterrupt when maximum minutes have elapsed."""
     tpot_obj = TPOTClassifier(config_dict='TPOT light')
     tpot_obj._start_datetime = datetime.now()
-    sleep(0.1)
+    sleep(0.11)
     tpot_obj.max_time_mins = 0.1/60.
     assert_raises(KeyboardInterrupt, tpot_obj._stop_by_max_time_mins)
 

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -924,6 +924,12 @@ def test_stop_by_max_time_mins():
     assert_raises(KeyboardInterrupt, tpot_obj._stop_by_max_time_mins)
 
 
+def test_update_evaluated_individuals_():
+    """Assert that _update_evaluated_individuals_ raises ValueError when scoring function does not return a float."""
+    tpot_obj = TPOTClassifier(config_dict='TPOT light')
+    assert_raises(ValueError, tpot_obj._update_evaluated_individuals_, ['Non-Float-Score'], ['Test_Pipeline'], [1])
+
+
 def test_evaluate_individuals():
     """Assert that _evaluate_individuals returns operator_counts and CV scores in correct order."""
     tpot_obj = TPOTClassifier(

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -1433,10 +1433,9 @@ def test_varOr():
         ind.fitness.values = (2, 1.0)
 
     offspring = varOr(pop, tpot_obj._toolbox, 5, cxpb=1.0, mutpb=0.0)
-
+    invalid_ind = [ind for ind in offspring if not ind.fitness.valid]
     assert len(offspring) == 5
-    for ind in offspring:
-        assert not ind.fitness.values
+    assert len(invalid_ind) == 5
 
 
 def test_varOr_2():
@@ -1451,12 +1450,12 @@ def test_varOr_2():
     pop = tpot_obj._toolbox.population(n=5)
     for ind in pop:
         ind.fitness.values = (2, 1.0)
+        print(type(ind.fitness.values))
 
     offspring = varOr(pop, tpot_obj._toolbox, 5, cxpb=0.0, mutpb=1.0)
-
+    invalid_ind = [ind for ind in offspring if not ind.fitness.valid]
     assert len(offspring) == 5
-    for ind in offspring:
-        assert not ind.fitness.values
+    assert len(invalid_ind) == 5
 
 
 def test_varOr_3():
@@ -1473,10 +1472,9 @@ def test_varOr_3():
         ind.fitness.values = (2, 1.0)
 
     offspring = varOr(pop, tpot_obj._toolbox, 5, cxpb=0.0, mutpb=0.0)
-
+    invalid_ind = [ind for ind in offspring if not ind.fitness.valid]
     assert len(offspring) == 5
-    for ind in offspring:
-        assert ind.fitness.values
+    assert len(invalid_ind) == 0
 
 
 def test_operator_type():

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -651,7 +651,7 @@ def test_fit_2():
 
 
 def test_fit_3():
-    """Assert that the TPOT fit function provides an optimized pipeline with subsample is 0.8."""
+    """Assert that the TPOT fit function provides an optimized pipeline with subsample of 0.8."""
     tpot_obj = TPOTClassifier(
         random_state=42,
         population_size=1,
@@ -663,6 +663,29 @@ def test_fit_3():
     )
     tpot_obj.fit(training_features, training_target)
 
+    assert isinstance(tpot_obj._optimized_pipeline, creator.Individual)
+    assert not (tpot_obj._start_datetime is None)
+
+
+def test_fit_4():
+    """Assert that the TPOT fit function provides an optimized pipeline with max_time_mins of 1 seconds"""
+    tpot_obj = TPOTClassifier(
+        random_state=42,
+        population_size=5,
+        generations=1,
+        verbosity=0,
+        max_time_mins=1/60.,
+        config_dict='TPOT light'
+    )
+    assert tpot_obj.generations == 1000000
+
+    # reset generations to 10 just in case that the failed test may take too much time
+    tpot_obj.generations == 100
+
+    tpot_obj.fit(training_features, training_target)
+    total_mins_elapsed = (datetime.now() - tpot_obj._start_datetime).total_seconds() / 60.
+    # allow two seconds more
+    assert total_mins_elapsed < 3/60.
     assert isinstance(tpot_obj._optimized_pipeline, creator.Individual)
     assert not (tpot_obj._start_datetime is None)
 

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -1434,6 +1434,7 @@ def test_varOr():
 
     offspring = varOr(pop, tpot_obj._toolbox, 5, cxpb=1.0, mutpb=0.0)
     invalid_ind = [ind for ind in offspring if not ind.fitness.valid]
+    
     assert len(offspring) == 5
     assert len(invalid_ind) == 5
 
@@ -1454,6 +1455,7 @@ def test_varOr_2():
 
     offspring = varOr(pop, tpot_obj._toolbox, 5, cxpb=0.0, mutpb=1.0)
     invalid_ind = [ind for ind in offspring if not ind.fitness.valid]
+
     assert len(offspring) == 5
     assert len(invalid_ind) == 5
 
@@ -1473,6 +1475,7 @@ def test_varOr_3():
 
     offspring = varOr(pop, tpot_obj._toolbox, 5, cxpb=0.0, mutpb=0.0)
     invalid_ind = [ind for ind in offspring if not ind.fitness.valid]
+
     assert len(offspring) == 5
     assert len(invalid_ind) == 0
 

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -1404,17 +1404,19 @@ def test_mutNodeReplacement():
     pipeline[0].ret = Output_Array
     old_ret_type_list = [node.ret for node in pipeline]
     old_prims_list = [node for node in pipeline if node.arity != 0]
-    mut_ind = mutNodeReplacement(pipeline, pset=tpot_obj._pset)
-    new_ret_type_list = [node.ret for node in mut_ind[0]]
-    new_prims_list = [node for node in mut_ind[0] if node.arity != 0]
+    # test 10 times
+    for _ in range(10):
+        mut_ind = mutNodeReplacement(tpot_obj._toolbox.clone(pipeline), pset=tpot_obj._pset)
+        new_ret_type_list = [node.ret for node in mut_ind[0]]
+        new_prims_list = [node for node in mut_ind[0] if node.arity != 0]
 
-    if new_prims_list == old_prims_list:  # Terminal mutated
-        assert new_ret_type_list == old_ret_type_list
-    else:  # Primitive mutated
-        diff_prims = list(set(new_prims_list).symmetric_difference(old_prims_list))
-        assert diff_prims[0].ret == diff_prims[1].ret
+        if new_prims_list == old_prims_list:  # Terminal mutated
+            assert new_ret_type_list == old_ret_type_list
+        else:  # Primitive mutated
+            diff_prims = list(set(new_prims_list).symmetric_difference(old_prims_list))
+            assert diff_prims[0].ret == diff_prims[1].ret
 
-    assert mut_ind[0][0].ret == Output_Array
+        assert mut_ind[0][0].ret == Output_Array
 
 
 def test_operator_type():

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -988,7 +988,6 @@ class TPOTBase(BaseEstimator):
             according to its performance on the provided data
 
         """
-        self._stop_by_max_time_mins()
 
         operator_counts, eval_individuals_str, sklearn_pipeline_list = self._preprocess_individuals(individuals)
 
@@ -1008,11 +1007,13 @@ class TPOTBase(BaseEstimator):
         # Don't use parallelization if n_jobs==1
         if self.n_jobs == 1:
             for sklearn_pipeline in sklearn_pipeline_list:
+                self._stop_by_max_time_mins()
                 val = partial_wrapped_cross_val_score(sklearn_pipeline=sklearn_pipeline)
                 result_score_list = self._update_val(val, result_score_list)
         else:
             # chunk size for pbar update
             for chunk_idx in range(0, len(sklearn_pipeline_list), self.n_jobs * 4):
+                self._stop_by_max_time_mins()
                 parallel = Parallel(n_jobs=self.n_jobs, verbose=0, pre_dispatch='2*n_jobs')
                 tmp_result_scores = parallel(delayed(partial_wrapped_cross_val_score)(sklearn_pipeline=sklearn_pipeline)
                                              for sklearn_pipeline in sklearn_pipeline_list[chunk_idx:chunk_idx + self.n_jobs * 4])

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -566,7 +566,6 @@ class TPOTBase(BaseEstimator):
                     pbar=self._pbar,
                     halloffame=self._pareto_front,
                     verbose=self.verbosity,
-                    max_time_mins=self.max_time_mins,
                     per_generation_function=partial(self._save_pipeline_if_period, features=features, target=target)
                 )
 
@@ -1045,6 +1044,9 @@ class TPOTBase(BaseEstimator):
         sklearn_pipeline_list: list
             a list of scikit-learn pipelines converted from DEAP individuals for evaluation
         """
+        # update self._pbar.total
+        if not (self.max_time_mins is None) and not self._pbar.disable and self._pbar.total <= self._pbar.n:
+            self._pbar.total += self.offspring_size
         # Check we do not evaluate twice the same individual in one pass.
         _, unique_individual_indices = np.unique([str(ind) for ind in individuals], return_index=True)
         unique_individuals = [ind for i, ind in enumerate(individuals) if i in unique_individual_indices]

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -822,7 +822,7 @@ class TPOTBase(BaseEstimator):
             try:
                 self._update_top_pipeline(features, target)
                 filename = os.path.join(self.periodic_checkpoint_folder, 'pipeline_{}.py'.format(datetime.now().strftime('%Y.%m.%d_%H-%M-%S')))
-                
+
                 did_export = self.export(filename, skip_if_repeated=True)
                 if not did_export:
                     self._update_pbar(pbar_num=0, pbar_msg='Periodic pipeline was not saved, probably saved before...')
@@ -956,6 +956,14 @@ class TPOTBase(BaseEstimator):
                 setattr(obj, parameter, value)
 
 
+    def _stop_by_max_time_mins(self):
+        """Stop optimization process once maximum minutes have elapsed."""
+        if self.max_time_mins:
+            total_mins_elapsed = (datetime.now() - self._start_datetime).total_seconds() / 60.
+            if total_mins_elapsed >= self.max_time_mins:
+                raise KeyboardInterrupt('{} minutes have elapsed. TPOT will close down.'.format(total_mins_elapsed))
+
+
     def _evaluate_individuals(self, individuals, features, target, sample_weight=None, groups=None):
         """Determine the fit of the provided individuals.
 
@@ -980,10 +988,7 @@ class TPOTBase(BaseEstimator):
             according to its performance on the provided data
 
         """
-        if self.max_time_mins:
-            total_mins_elapsed = (datetime.now() - self._start_datetime).total_seconds() / 60.
-            if total_mins_elapsed >= self.max_time_mins:
-                raise KeyboardInterrupt('{} minutes have elapsed. TPOT will close down.'.format(total_mins_elapsed))
+        self._stop_by_max_time_mins()
 
         operator_counts, eval_individuals_str, sklearn_pipeline_list = self._preprocess_individuals(individuals)
 

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1021,11 +1021,7 @@ class TPOTBase(BaseEstimator):
                 for val in tmp_result_scores:
                     result_score_list = self._update_val(val, result_score_list)
 
-        for result_score, individual_str in zip(result_score_list, eval_individuals_str):
-            if type(result_score) in [float, np.float64, np.float32]:
-                self.evaluated_individuals_[individual_str] = (operator_counts[individual_str], result_score)
-            else:
-                raise ValueError('Scoring function does not return a float.')
+        self._update_evaluated_individuals_(result_score_list, eval_individuals_str, operator_counts)
 
         return [self.evaluated_individuals_[str(individual)] for individual in individuals]
 
@@ -1099,8 +1095,30 @@ class TPOTBase(BaseEstimator):
         return operator_counts, eval_individuals_str, sklearn_pipeline_list
 
 
+    def _update_evaluated_individuals_(self, result_score_list, eval_individuals_str, operator_counts):
+        """Update self.evaluated_individuals_ and error message during pipeline evaluation.
+        Parameters
+        ----------
+        result_score_list: list
+            A list of CV scores for evaluated pipelines
+        eval_individuals_str: list
+            A list of strings for evaluated pipelines
+        operator_counts: list
+            A list of operator counts for evaluated pipelines
+
+        Returns
+        -------
+        None
+        """
+        for result_score, individual_str in zip(result_score_list, eval_individuals_str):
+            if type(result_score) in [float, np.float64, np.float32]:
+                self.evaluated_individuals_[individual_str] = (operator_counts[individual_str], result_score)
+            else:
+                raise ValueError('Scoring function does not return a float.')
+
+
     def _update_pbar(self, pbar_num=1, pbar_msg=None):
-        """Update self._pbar and error message during pipeline evaluration.
+        """Update self._pbar and error message during pipeline evaluation.
 
         Parameters
         ----------

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -278,26 +278,17 @@ def cxOnePoint(ind1, ind2):
     # Define the name of type for any types.
     __type__ = object
 
-    if len(ind1) < 2 or len(ind2) < 2:
-        # No crossover on single node tree
-        return ind1, ind2
-
     # List all available primitive types in each individual
     types1 = defaultdict(list)
     types2 = defaultdict(list)
-    if ind1.root.ret == __type__:
-        # Not STGP optimization
-        types1[__type__] = range(1, len(ind1))
-        types2[__type__] = range(1, len(ind2))
-        common_types = [__type__]
-    else:
-        for idx, node in enumerate(ind1[1:], 1):
-            types1[node.ret].append(idx)
-        common_types = []
-        for idx, node in enumerate(ind2[1:], 1):
-            if node.ret in types1 and node.ret not in types2:
-                common_types.append(node.ret)
-            types2[node.ret].append(idx)
+
+    for idx, node in enumerate(ind1[1:], 1):
+        types1[node.ret].append(idx)
+    common_types = []
+    for idx, node in enumerate(ind2[1:], 1):
+        if node.ret in types1 and node.ret not in types2:
+            common_types.append(node.ret)
+        types2[node.ret].append(idx)
 
     if len(common_types) > 0:
         type_ = np.random.choice(common_types)

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -151,8 +151,7 @@ def varOr(population, toolbox, lambda_, cxpb, mutpb):
 
 
 def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen, pbar,
-                   stats=None, halloffame=None, verbose=0, max_time_mins=None,
-                   per_generation_function=None):
+                   stats=None, halloffame=None, verbose=0, per_generation_function=None):
     """This is the :math:`(\mu + \lambda)` evolutionary algorithm.
     :param population: A list of individuals.
     :param toolbox: A :class:`~deap.base.Toolbox` that contains the evolution
@@ -225,11 +224,9 @@ def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen, pbar,
         # Evaluate the individuals with an invalid fitness
         invalid_ind = [ind for ind in offspring if not ind.fitness.valid]
 
-        # update pbar for valid_ind
+        # update pbar for valid individuals (with fitness values)
         if not pbar.disable:
             pbar.update(len(offspring)-len(invalid_ind))
-            if not (max_time_mins is None) and pbar.n >= pbar.total:
-                pbar.total += lambda_
 
         fitnesses = toolbox.evaluate(invalid_ind)
         for ind, fit in zip(invalid_ind, fitnesses):


### PR DESCRIPTION
## What does this PR do?

1. Refines _evaluate_individuals  to make `max_time_mins` can stop optimization during pipeline evaluation rather than at beginning of each generation.

2. Removes redundant codes in `cxOnePoint`

3. More unit tests for increasing code coverage.
