### PR TITLE
Use f_regression for feature selection in regression tasks

### DIFF
--- a/tpot/config/regressor.py
+++ b/tpot/config/regressor.py
@@ -162,14 +162,14 @@ regressor_config_dict = {
     'sklearn.feature_selection.SelectFwe': {
         'alpha': np.arange(0, 0.05, 0.001),
         'score_func': {
-            'sklearn.feature_selection.f_classif': None
+            'sklearn.feature_selection.f_regression': None
         }
     },
 
     'sklearn.feature_selection.SelectPercentile': {
         'percentile': range(1, 100),
         'score_func': {
-            'sklearn.feature_selection.f_classif': None
+            'sklearn.feature_selection.f_regression': None
         }
     },
 

--- a/tpot/config/regressor_light.py
+++ b/tpot/config/regressor_light.py
@@ -105,14 +105,14 @@ regressor_config_dict_light = {
     'sklearn.feature_selection.SelectFwe': {
         'alpha': np.arange(0, 0.05, 0.001),
         'score_func': {
-            'sklearn.feature_selection.f_classif': None
+            'sklearn.feature_selection.f_regression': None
         }
     },
 
     'sklearn.feature_selection.SelectPercentile': {
         'percentile': range(1, 100),
         'score_func': {
-            'sklearn.feature_selection.f_classif': None
+            'sklearn.feature_selection.f_regression': None
         }
     },
 

--- a/tpot/config/regressor_sparse.py
+++ b/tpot/config/regressor_sparse.py
@@ -42,14 +42,14 @@ regressor_config_sparse = {
     'sklearn.feature_selection.SelectFwe': {
         'alpha': np.arange(0, 0.05, 0.001),
         'score_func': {
-            'sklearn.feature_selection.f_classif': None
+            'sklearn.feature_selection.f_regression': None
         }
     },
 
     'sklearn.feature_selection.SelectPercentile': {
         'percentile': range(1, 100),
         'score_func': {
-            'sklearn.feature_selection.f_classif': None
+            'sklearn.feature_selection.f_regression': None
         }
     },
 

--- a/tpot/operator_utils.py
+++ b/tpot/operator_utils.py
@@ -243,7 +243,7 @@ def TPOTOperatorClassFactory(opsourse, opdict, BaseClass=Operator, ArgBaseClass=
                 # To make sure the inital operators is the first parameter just
                 # for better persentation
                 for dep_op_pname, dep_op_str in dep_op_list.items():
-                    if dep_op_str == 'f_classif':
+                    if dep_op_str in ['f_classif', 'f_regression']:
                         arg_value = dep_op_str
                     else:
                         arg_value = "{}({})".format(dep_op_str, ", ".join(dep_op_arguments[dep_op_str]))


### PR DESCRIPTION
## What does this PR do?

Use `sklearn.feature_selection.f_regression` instead of `sklearn.feature_selection.f_classif` for regression tasks.

Related issue #536 
