### PR TITLE
Add "early stopping" option for stopping optimization process

### DIFF
--- a/docs_sources/api.md
+++ b/docs_sources/api.md
@@ -161,7 +161,7 @@ Useful in multiple cases:
 <strong>early_stop</strong>: integer, optional (default: None)
 <blockquote>
 How many generations TPOT checks whether there is no improvement in optimization process.<br /><br />
-Kill optimization process if there is no improvement in the set number of generations.<br /><br />
+End optimization process if there is no improvement in the set number of generations.<br /><br />
 </blockquote>
 
 <strong>verbosity</strong>: integer, optional (default=0)
@@ -614,7 +614,7 @@ Useful in multiple cases:
 <strong>early_stop</strong>: integer, optional (default: None)
 <blockquote>
 How many generations TPOT checks whether there is no improvement in optimization process.<br /><br />
-Kill optimization process if there is no improvement in the set number of generations.<br /><br />
+End optimization process if there is no improvement in the set number of generations.<br /><br />
 </blockquote>
 
 <strong>verbosity</strong>: integer, optional (default=0)

--- a/docs_sources/api.md
+++ b/docs_sources/api.md
@@ -158,6 +158,12 @@ Useful in multiple cases:
 </ul>
 </blockquote>
 
+<strong>early_stop</strong>: integer, optional (default: None)
+<blockquote>
+How many generations TPOT checks whether there is no improvement in optimization process.<br /><br />
+Kill optimization process if there is no improvement in the set number of generations.<br /><br />
+</blockquote>
+
 <strong>verbosity</strong>: integer, optional (default=0)
 <blockquote>
 How much information TPOT communicates while it's running.
@@ -603,6 +609,12 @@ Useful in multiple cases:
 <li>Track its progress</li>
 <li>Grab pipelines while it's still optimizing</li>
 </ul>
+</blockquote>
+
+<strong>early_stop</strong>: integer, optional (default: None)
+<blockquote>
+How many generations TPOT checks whether there is no improvement in optimization process.<br /><br />
+Kill optimization process if there is no improvement in the set number of generations.<br /><br />
 </blockquote>
 
 <strong>verbosity</strong>: integer, optional (default=0)

--- a/docs_sources/using.md
+++ b/docs_sources/using.md
@@ -224,7 +224,7 @@ See the section on <a href="#scoring-functions">scoring functions</a> for more d
 <tr>
 <td>-cv</td>
 <td>CV</td>
-<td>Any integer >1</td>
+<td>Any integer > 1</td>
 <td>Number of folds to evaluate each pipeline over in k-fold cross-validation during the TPOT optimization process.</td>
 </tr>
 <td>-sub</td>
@@ -283,6 +283,15 @@ Example:
 mkdir my_checkpoints
 <br />
 -cf ./my_checkpoints
+</tr>
+<tr>
+<td>-es</td>
+<td>EARLY_STOP</td>
+<td>Any positive integer</td>
+<td>
+How many generations TPOT checks whether there is no improvement in optimization process.
+<br /><br />
+Kill optimization process if there is no improvement in the set number of generations.
 </tr>
 <tr>
 <td>-v</td>

--- a/docs_sources/using.md
+++ b/docs_sources/using.md
@@ -291,7 +291,7 @@ mkdir my_checkpoints
 <td>
 How many generations TPOT checks whether there is no improvement in optimization process.
 <br /><br />
-Kill optimization process if there is no improvement in the set number of generations.
+End optimization process if there is no improvement in the set number of generations.
 </tr>
 <tr>
 <td>-v</td>

--- a/tests/driver_tests.py
+++ b/tests/driver_tests.py
@@ -219,7 +219,9 @@ class ParserTest(TestCase):
     def test_default_param(self):
         """Assert that the TPOT driver stores correct default values for all parameters."""
         args = self.parser.parse_args(['tests/tests.csv'])
+        self.assertEqual(args.CONFIG_FILE, None)
         self.assertEqual(args.CROSSOVER_RATE, 0.1)
+        self.assertEqual(args.EARLY_STOP, None)
         self.assertEqual(args.DISABLE_UPDATE_CHECK, False)
         self.assertEqual(args.GENERATIONS, 100)
         self.assertEqual(args.INPUT_FILE, 'tests/tests.csv')
@@ -249,6 +251,7 @@ class ParserTest(TestCase):
 TPOT settings:
 CONFIG_FILE\t=\tNone
 CROSSOVER_RATE\t=\t0.1
+EARLY_STOP\t=\tNone
 GENERATIONS\t=\t100
 INPUT_FILE\t=\ttests/tests.csv
 INPUT_SEPARATOR\t=\t\t
@@ -287,6 +290,7 @@ VERBOSITY\t=\t1
 TPOT settings:
 CONFIG_FILE\t=\tNone
 CROSSOVER_RATE\t=\t0.1
+EARLY_STOP\t=\tNone
 GENERATIONS\t=\t100
 INPUT_FILE\t=\ttests/tests.csv
 INPUT_SEPARATOR\t=\t\t

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -851,6 +851,21 @@ def test_update_top_pipeline_3():
     assert_raises(RuntimeError, tpot_obj._update_top_pipeline)
 
 
+def test_summary_of_best_pipeline():
+    """Assert that the TPOT _update_top_pipeline raises RuntimeError when self._optimized_pipeline is not updated."""
+    tpot_obj = TPOTClassifier(
+        random_state=42,
+        population_size=1,
+        offspring_size=2,
+        generations=1,
+        verbosity=0,
+        config_dict='TPOT light'
+    )
+
+    assert_raises(RuntimeError, tpot_obj._summary_of_best_pipeline, features=training_features, target=training_target)
+
+
+
 def test_set_param_recursive():
     """Assert that _set_param_recursive sets \"random_state\" to 42 in all steps in a simple pipeline."""
     pipeline_string = (

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -746,6 +746,25 @@ def test_check_periodic_pipeline_2():
                 os.remove(os.path.join('./', f))
 
 
+def test_check_periodic_pipeline_3():
+    """Assert that the _check_periodic_pipeline rasie KeyboardInterrupt if self._last_optimized_pipeline_n_gens >= self.early_stop."""
+    tpot_obj = TPOTClassifier(
+        random_state=42,
+        population_size=1,
+        offspring_size=2,
+        generations=1,
+        verbosity=0,
+        config_dict='TPOT light',
+        early_stop=3
+    )
+    tpot_obj.fit(training_features, training_target)
+    tpot_obj._last_optimized_pipeline_n_gens = 2
+    # will pass
+    tpot_obj._check_periodic_pipeline()
+    tpot_obj._last_optimized_pipeline_n_gens = 3
+    assert_raises(KeyboardInterrupt, tpot_obj._check_periodic_pipeline)
+
+
 def test_save_periodic_pipeline():
     """Assert that the _save_periodic_pipeline does not export periodic pipeline if exception happened"""
     tpot_obj = TPOTClassifier(
@@ -863,7 +882,6 @@ def test_summary_of_best_pipeline():
     )
 
     assert_raises(RuntimeError, tpot_obj._summary_of_best_pipeline, features=training_features, target=training_target)
-
 
 
 def test_set_param_recursive():

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -747,7 +747,7 @@ def test_check_periodic_pipeline_2():
 
 
 def test_check_periodic_pipeline_3():
-    """Assert that the _check_periodic_pipeline rasie StopIteration if self._last_optimized_pipeline_n_gens >= self.early_stop."""
+    """Assert that the _check_periodic_pipeline rasie StopIteration if self._last_optimized_pareto_front_n_gens >= self.early_stop."""
     tpot_obj = TPOTClassifier(
         random_state=42,
         population_size=1,
@@ -760,7 +760,7 @@ def test_check_periodic_pipeline_3():
     tpot_obj.early_stop = 3
     # will pass
     tpot_obj._check_periodic_pipeline()
-    tpot_obj._last_optimized_pipeline_n_gens = 3
+    tpot_obj._last_optimized_pareto_front_n_gens = 3
     assert_raises(StopIteration, tpot_obj._check_periodic_pipeline)
 
 

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -688,8 +688,8 @@ def test_fit_4():
     assert not (tpot_obj._start_datetime is None)
 
 
-def test_save_pipeline_if_period():
-    """Assert that the _save_pipeline_if_period exports periodic pipeline."""
+def test_check_periodic_pipeline():
+    """Assert that the _check_periodic_pipeline exports periodic pipeline."""
     tpot_obj = TPOTClassifier(
         random_state=42,
         population_size=1,
@@ -706,7 +706,7 @@ def test_save_pipeline_if_period():
         sleep(0.11)
         tpot_obj._output_best_pipeline_period_seconds = 0.1
         tpot_obj.periodic_checkpoint_folder = './'
-        tpot_obj._save_pipeline_if_period(training_features, training_target)
+        tpot_obj._check_periodic_pipeline()
         our_file.seek(0)
 
         assert_in('Saving best periodic pipeline to ./pipeline', our_file.read())
@@ -716,8 +716,8 @@ def test_save_pipeline_if_period():
                 os.remove(os.path.join('./', f))
 
 
-def test_save_pipeline_if_period_2():
-    """Assert that the _save_pipeline_if_period does not export periodic pipeline if the pipeline has been saved before."""
+def test_check_periodic_pipeline_2():
+    """Assert that the _check_periodic_pipeline does not export periodic pipeline if the pipeline has been saved before."""
     tpot_obj = TPOTClassifier(
         random_state=42,
         population_size=1,
@@ -736,7 +736,7 @@ def test_save_pipeline_if_period_2():
         tpot_obj.periodic_checkpoint_folder = './'
         # export once before
         tpot_obj.export('./pipeline_test.py')
-        tpot_obj._save_pipeline_if_period(training_features, training_target)
+        tpot_obj._check_periodic_pipeline()
         our_file.seek(0)
 
         assert_in('Periodic pipeline was not saved, probably saved before...', our_file.read())
@@ -746,8 +746,8 @@ def test_save_pipeline_if_period_2():
                 os.remove(os.path.join('./', f))
 
 
-def test_save_pipeline_if_period_3():
-    """Assert that the _save_pipeline_if_period does not export periodic pipeline if exception happened"""
+def test_save_periodic_pipeline():
+    """Assert that the _save_periodic_pipeline does not export periodic pipeline if exception happened"""
     tpot_obj = TPOTClassifier(
         random_state=42,
         population_size=1,
@@ -764,13 +764,10 @@ def test_save_pipeline_if_period_3():
         sleep(0.11)
         tpot_obj._output_best_pipeline_period_seconds = 0.1
         tpot_obj.periodic_checkpoint_folder = './'
-        # reset _optimized_pipeline
+        # reset _optimized_pipeline to rasie exception
         tpot_obj._optimized_pipeline = None
-        # reset pipeline_scores in tpot_obj._pareto_front to cause exception
-        for pipeline_scores in reversed(tpot_obj._pareto_front.keys):
-            pipeline_scores.wvalues = (5000., -float('inf'))
 
-        tpot_obj._save_pipeline_if_period(training_features, training_target)
+        tpot_obj._save_periodic_pipeline()
         our_file.seek(0)
 
         assert_in('Failed saving periodic pipeline, exception', our_file.read())
@@ -810,10 +807,9 @@ def test_update_top_pipeline():
     tpot_obj.fit(training_features, training_target)
     tpot_obj._optimized_pipeline = None
     tpot_obj.fitted_pipeline_ = None
-    tpot_obj._update_top_pipeline(training_features, training_target)
+    tpot_obj._update_top_pipeline()
 
     assert isinstance(tpot_obj._optimized_pipeline, creator.Individual)
-    assert not (tpot_obj.fitted_pipeline_ is None)
 
 
 def test_update_top_pipeline_2():
@@ -833,7 +829,7 @@ def test_update_top_pipeline_2():
 
     tpot_obj._pareto_front = ParetoFront(similar=pareto_eq)
 
-    assert_raises(RuntimeError, tpot_obj._update_top_pipeline, features=training_features, target=training_target)
+    assert_raises(RuntimeError, tpot_obj._update_top_pipeline)
 
 
 def test_update_top_pipeline_3():
@@ -852,7 +848,7 @@ def test_update_top_pipeline_3():
     for pipeline_scores in reversed(tpot_obj._pareto_front.keys):
         pipeline_scores.wvalues = (5000., -float('inf'))
 
-    assert_raises(RuntimeError, tpot_obj._update_top_pipeline, features=training_features, target=training_target)
+    assert_raises(RuntimeError, tpot_obj._update_top_pipeline)
 
 
 def test_set_param_recursive():

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -747,22 +747,21 @@ def test_check_periodic_pipeline_2():
 
 
 def test_check_periodic_pipeline_3():
-    """Assert that the _check_periodic_pipeline rasie KeyboardInterrupt if self._last_optimized_pipeline_n_gens >= self.early_stop."""
+    """Assert that the _check_periodic_pipeline rasie StopIteration if self._last_optimized_pipeline_n_gens >= self.early_stop."""
     tpot_obj = TPOTClassifier(
         random_state=42,
         population_size=1,
         offspring_size=2,
         generations=1,
         verbosity=0,
-        config_dict='TPOT light',
-        early_stop=3
+        config_dict='TPOT light'
     )
     tpot_obj.fit(training_features, training_target)
-    tpot_obj._last_optimized_pipeline_n_gens = 2
+    tpot_obj.early_stop = 3
     # will pass
     tpot_obj._check_periodic_pipeline()
     tpot_obj._last_optimized_pipeline_n_gens = 3
-    assert_raises(KeyboardInterrupt, tpot_obj._check_periodic_pipeline)
+    assert_raises(StopIteration, tpot_obj._check_periodic_pipeline)
 
 
 def test_save_periodic_pipeline():

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -432,6 +432,7 @@ class TPOTBase(BaseEstimator):
 
         self._pset.addPrimitive(CombineDFs(), [np.ndarray, np.ndarray], np.ndarray)
 
+
     def _add_terminals(self):
         for _type in self.arguments:
             type_values = list(_type.values)
@@ -439,6 +440,7 @@ class TPOTBase(BaseEstimator):
             for val in type_values:
                 terminal_name = _type.__name__ + "=" + str(val)
                 self._pset.addTerminal(val, _type, name=terminal_name)
+
 
     def _setup_toolbox(self):
         creator.create('FitnessMulti', base.Fitness, weights=(-1.0, 1.0))
@@ -453,6 +455,7 @@ class TPOTBase(BaseEstimator):
         self._toolbox.register('mate', self._mate_operator)
         self._toolbox.register('expr_mut', self._gen_grow_safe, min_=1, max_=4)
         self._toolbox.register('mutate', self._random_mutation_operator)
+
 
     def fit(self, features, target, sample_weight=None, groups=None):
         """Fit an optimized machine learning pipeline.

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -200,7 +200,7 @@ class TPOTBase(BaseEstimator):
                 Grab pipelines while it's still optimizing
         early_stop: int or None (default: None)
             How many generations TPOT checks whether there is no improvement in optimization process.
-            Kill optimization process if there is no improvement.
+            Kill optimization process if there is no improvement in the set number of generations.
         verbosity: int, optional (default: 0)
             How much information TPOT communicates while it's running.
             0 = none, 1 = minimal, 2 = high, 3 = all.

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -332,6 +332,7 @@ class TPOTBase(BaseEstimator):
         self._setup_toolbox()
         self._setup_pop(population_seeds, config_dict)
 
+
     def _setup_config(self, config_dict):
         if config_dict:
             if isinstance(config_dict, dict):

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -839,7 +839,7 @@ class TPOTBase(BaseEstimator):
             total_since_last_pipeline_save = (datetime.now() - self._last_pipeline_write).total_seconds()
             if total_since_last_pipeline_save > self._output_best_pipeline_period_seconds:
                 self._last_pipeline_write = datetime.now()
-                self._save_periodic_pipeline(features, target)
+                self._save_periodic_pipeline()
 
         if self.early_stop is not None:
             if self._last_optimized_pipeline_n_gens >= self.early_stop:
@@ -850,7 +850,6 @@ class TPOTBase(BaseEstimator):
     def _save_periodic_pipeline(self):
         try:
             filename = os.path.join(self.periodic_checkpoint_folder, 'pipeline_{}.py'.format(datetime.now().strftime('%Y.%m.%d_%H-%M-%S')))
-
             did_export = self.export(filename, skip_if_repeated=True)
             if not did_export:
                 self._update_pbar(pbar_num=0, pbar_msg='Periodic pipeline was not saved, probably saved before...')

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -199,7 +199,7 @@ class TPOTBase(BaseEstimator):
                 Track its progress
                 Grab pipelines while it's still optimizing
         early_stop: int or None (default: None)
-            How many generations TPOT checks whether there is any improvement in optimization process.
+            How many generations TPOT checks whether there is no improvement in optimization process.
             Kill optimization process if there is no improvement.
         verbosity: int, optional (default: 0)
             How much information TPOT communicates while it's running.
@@ -586,7 +586,7 @@ class TPOTBase(BaseEstimator):
                 self._pop = pop
 
         # Allow for certain exceptions to signal a premature fit() cancellation
-        except (KeyboardInterrupt, SystemExit) as e:
+        except (KeyboardInterrupt, SystemExit, StopIteration) as e:
             if self.verbosity > 0:
                 self._pbar.write('', file=self._file)
                 self._pbar.write('{}\nTPOT closed prematurely. Will use the current best pipeline.'.format(e),
@@ -605,11 +605,12 @@ class TPOTBase(BaseEstimator):
                     self._summary_of_best_pipeline(features, target)
                     break
 
-                except (KeyboardInterrupt, SystemExit, Exception):
+                except (KeyboardInterrupt, SystemExit, Exception) as e:
                     # raise the exception if it's our last attempt
                     if attempt == (attempts - 1):
-                        raise
+                        raise e
             return self
+
 
     def _update_top_pipeline(self):
         """Helper function to update the _optimized_pipeline field.
@@ -847,7 +848,7 @@ class TPOTBase(BaseEstimator):
 
         if self.early_stop is not None:
             if self._last_optimized_pipeline_n_gens >= self.early_stop:
-                raise KeyboardInterrupt("The optimized pipeline was not improved after evaluating {} more generations. "
+                raise StopIteration("The optimized pipeline was not improved after evaluating {} more generations. "
                                         "Will kill the optimization process.\n".format(self.early_stop))
 
 

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -200,7 +200,7 @@ class TPOTBase(BaseEstimator):
                 Grab pipelines while it's still optimizing
         early_stop: int or None (default: None)
             How many generations TPOT checks whether there is no improvement in optimization process.
-            Kill optimization process if there is no improvement in the set number of generations.
+            End optimization process if there is no improvement in the set number of generations.
         verbosity: int, optional (default: 0)
             How much information TPOT communicates while it's running.
             0 = none, 1 = minimal, 2 = high, 3 = all.
@@ -849,7 +849,7 @@ class TPOTBase(BaseEstimator):
         if self.early_stop is not None:
             if self._last_optimized_pipeline_n_gens >= self.early_stop:
                 raise StopIteration("The optimized pipeline was not improved after evaluating {} more generations. "
-                                        "Will kill the optimization process.\n".format(self.early_stop))
+                                        "Will end the optimization process.\n".format(self.early_stop))
 
 
     def _save_periodic_pipeline(self):

--- a/tpot/driver.py
+++ b/tpot/driver.py
@@ -372,7 +372,7 @@ def _get_arg_parser():
         type=int,
         help=(
             'How many generations TPOT checks whether there is no improvement '
-            'in optimization process. Kill optimization process if there is no improvement '
+            'in optimization process. End optimization process if there is no improvement '
             'in the set number of generations.'
         )
     )

--- a/tpot/driver.py
+++ b/tpot/driver.py
@@ -282,20 +282,6 @@ def _get_arg_parser():
         )
     )
 
-    parser.add_argument(
-        '-cf',
-        action='store',
-        dest='CHECKPOINT_FOLDER',
-        default=None,
-        type=str,
-        help=('If supplied, a folder in which tpot will periodically '
-        'save the best pipeline so far while optimizing. '
-        'This is useful in multiple cases: '
-        'sudden death before tpot could save an optimized pipeline, '
-        'progress tracking, '
-        "grabbing a pipeline while it's still optimizing etc."
-        )
-    )
 
     parser.add_argument(
         '-njobs',
@@ -360,6 +346,33 @@ def _get_arg_parser():
             'that TPOT uses in the optimization process. Must be a Python '
             'module containing a dict export named "tpot_config" or the name of '
             'built-in configuration.'
+        )
+    )
+
+    parser.add_argument(
+        '-cf',
+        action='store',
+        dest='CHECKPOINT_FOLDER',
+        default=None,
+        type=str,
+        help=('If supplied, a folder in which tpot will periodically '
+        'save the best pipeline so far while optimizing. '
+        'This is useful in multiple cases: '
+        'sudden death before tpot could save an optimized pipeline, '
+        'progress tracking, '
+        "grabbing a pipeline while it's still optimizing etc."
+        )
+    )
+
+    parser.add_argument(
+        '-es',
+        action='store',
+        dest='EARLY_STOP',
+        default=None,
+        type=int,
+        help=(
+            'How many generations TPOT checks whether there is no improvement '
+            'in optimization process. Kill optimization process if there is no improvement.'
         )
     )
 
@@ -483,6 +496,7 @@ def tpot_driver(args):
         random_state=args.RANDOM_STATE,
         config_dict=args.CONFIG_FILE,
         periodic_checkpoint_folder=args.CHECKPOINT_FOLDER,
+        early_stop=args.EARLY_STOP,
         verbosity=args.VERBOSITY,
         disable_update_check=args.DISABLE_UPDATE_CHECK
     )

--- a/tpot/driver.py
+++ b/tpot/driver.py
@@ -372,7 +372,8 @@ def _get_arg_parser():
         type=int,
         help=(
             'How many generations TPOT checks whether there is no improvement '
-            'in optimization process. Kill optimization process if there is no improvement.'
+            'in optimization process. Kill optimization process if there is no improvement '
+            'in the set number of generations.'
         )
     )
 


### PR DESCRIPTION
## What does this PR do?

1. refine `self._check_periodic_pipeline`

2. Add "early stopping" option for stopping optimization process when no improvement in a set number of generations

## Where should the reviewer start?

[base.py](https://github.com/weixuanfu/tpot/blob/ca19ca479cc2b68ce8f54ef97ea23955728eadeb/tpot/base.py#L837)

## How should this PR be tested?

```
from tpot import TPOTClassifier
from sklearn.datasets import load_iris
from sklearn.model_selection import train_test_split
import numpy as np

iris = load_iris()
X_train, X_test, y_train, y_test = train_test_split(iris.data.astype(np.float64),
    iris.target.astype(np.float64), train_size=0.75, test_size=0.25, random_state=42)

tpot = TPOTClassifier(generations=20, population_size=10, verbosity=2, early_stop=2, random_state=42)
tpot.fit(X_train, y_train)
```


## What are the relevant issues?

#539 


## Questions:

- Do the docs need to be updated? Yes, docs were updated in the PR
- Does this PR add new (Python) dependencies? No
